### PR TITLE
Reworked the prop banning system and menu

### DIFF
--- a/gamemode/cl_bannedmodels.lua
+++ b/gamemode/cl_bannedmodels.lua
@@ -89,7 +89,6 @@ function GM:CreateBannedModelsMenu()
 		entry:SetEnabled(false)
 	end
 
-	-- What to do when the ENTER key is pressed on the text box.
 	function entry:OnEnter()
 		-- This client side check is for informational purposes.
 		if !LocalPlayer():IsAdmin() then
@@ -99,7 +98,7 @@ function GM:CreateBannedModelsMenu()
 
 		local modelToBan = entry:GetText()
 		-- This client side check is for informational purposes.
-		if string.len(modelToBan) == 0 then
+		if modelToBan == "" then
 			chat.AddText(Color(255, 50, 50), "Error when attempting to ban model: no input text was given.")
 			return
 		end
@@ -153,7 +152,6 @@ function GM:CreateBannedModelsMenu()
 		unbanButton:SetPos(0, modelIconHeight - unbanButton:GetTall())
 		unbanButton:SetVisible(false)
 
-		-- What to do when the unban button for a model is clicked.
 		function unbanButton:DoClick()
 			-- This client side check is for informational purposes.
 			if !LocalPlayer():IsAdmin() then

--- a/gamemode/cl_bannedmodels.lua
+++ b/gamemode/cl_bannedmodels.lua
@@ -13,7 +13,7 @@ end
 
 
 function GM:AddBannedModel(model)
-	if self.BannedModels[model] == true then return end -- Prevent duplicates.
+	if self.BannedModels[model] == true then return end
 
 	self.BannedModels[model] = true
 	menu.AddModel(model)
@@ -21,7 +21,7 @@ end
 
 
 function GM:RemoveBannedModel(model)
-	if self.BannedModels[model] != true then return end -- Check if exists before trying to remove.
+	if self.BannedModels[model] != true then return end
 
 	self.BannedModels[model] = nil
 	menu.RemoveModel(model)
@@ -31,23 +31,23 @@ end
 net.Receive("ph_bannedmodels_getall", function (len)
 	GAMEMODE.BannedModels = {}
 
-	local banned_model = net.ReadString()
-	while banned_model != "" do
-		GAMEMODE:AddBannedModel(banned_model)
-		banned_model = net.ReadString()
+	local model = net.ReadString()
+	while model != "" do
+		GAMEMODE:AddBannedModel(model)
+		model = net.ReadString()
 	end
 end)
 
 
 net.Receive("ph_bannedmodels_add", function (len)
-	local v = net.ReadString()
-	GAMEMODE:AddBannedModel(v)
+	local model = net.ReadString()
+	GAMEMODE:AddBannedModel(model)
 end)
 
 
 net.Receive("ph_bannedmodels_remove", function (len)
-	local v = net.ReadString()
-	GAMEMODE:RemoveBannedModel(v)
+	local model = net.ReadString()
+	GAMEMODE:RemoveBannedModel(model)
 end)
 
 
@@ -57,12 +57,10 @@ end)
 
 
 -- This is all the code to create the banned models menu.
--- TODO: I don't like adding this to GM. I feel like there should absolutely be a better solution.
 function GM:CreateBannedModelsMenu()
 	-- The main window that will contain all of the functionality for display, adding, and
 	-- removing banned models.
 	menu = vgui.Create("DFrame")
-	menu:SetPos(200, 200)
 	menu:SetSize(ScrW() * 0.4, ScrH() * 0.8)
 	menu:SetTitle("Banned Models")
 	menu:Center()
@@ -99,20 +97,20 @@ function GM:CreateBannedModelsMenu()
 			return
 		end
 
-		local model_to_ban = entry:GetText()
+		local modelToBan = entry:GetText()
 		-- This client side check is for informational purposes.
-		if string.len(model_to_ban) == 0 then
+		if string.len(modelToBan) == 0 then
 			chat.AddText(Color(255, 50, 50), "Error when attempting to ban model: no input text was given.")
 			return
 		end
 		-- This client side check is for informational purposes.
-		if GAMEMODE:IsModelBanned(model_to_ban) then
+		if GAMEMODE:IsModelBanned(modelToBan) then
 			chat.AddText(Color(255, 50, 50), "That model is already banned.")
 			return
 		end
 
 		net.Start("ph_bannedmodels_add")
-		net.WriteString(model_to_ban)
+		net.WriteString(modelToBan)
 		net.SendToServer()
 		entry:SetText("")
 	end
@@ -120,43 +118,43 @@ function GM:CreateBannedModelsMenu()
 	-- Makes a scroll bar on the right side in the event that there are a LOT of
 	-- banned models and we need to be able to scroll. Will not appear unless
 	-- there are enough items in the list to require it.
-	local scroll_panel = vgui.Create("DScrollPanel", menu)
-	scroll_panel:Dock(FILL)
+	local scrollPanel = vgui.Create("DScrollPanel", menu)
+	scrollPanel:Dock(FILL)
 	
-	local model_icon_width = 128
-	local model_icon_height = 128
-	local usable_width_for_model_icons = menu:GetWide() - scroll_panel:GetVBar():GetWide() -- Don't want icons to overlap the scroll bar.
-	local num_cols = math.floor(usable_width_for_model_icons / model_icon_width)
+	local modelIconWidth = 128
+	local modelIconHeight = 128
+	local usableWidthForModelIcons = menu:GetWide() - scrollPanel:GetVBar():GetWide() -- Don't want icons to overlap the scroll bar.
+	local numCols = math.floor(usableWidthForModelIcons / modelIconWidth)
 	-- This offset is almost right, but there's 10 pixels more on the left than on the right and I can't figure out why. :(
-	local left_offset = (usable_width_for_model_icons - (model_icon_width * num_cols)) / 2
+	local leftOffset = (usableWidthForModelIcons - (modelIconWidth * numCols)) / 2
 
 	-- This is the grid that will give the icons a nice layout.
-	local grid = vgui.Create("DGrid", scroll_panel)
+	local grid = vgui.Create("DGrid", scrollPanel)
 	menu.grid = grid
-	grid:SetCols(num_cols)
-	grid:SetPos(left_offset, 10)
-	grid:SetColWide(model_icon_width)
-	grid:SetRowHeight(model_icon_height)
+	grid:SetCols(numCols)
+	grid:SetPos(leftOffset, 10)
+	grid:SetColWide(modelIconWidth)
+	grid:SetRowHeight(modelIconHeight)
 
 	-- Allows functions outside of the menu to update the icons. Useful for updating the menu
 	-- live if it's open when a net message is received to add a model.
-	menu.AddModel = function(model)
-		local model_icon = vgui.Create("SpawnIcon")
-		model_icon:SetPos(75, 75)
-		model_icon:SetSize(model_icon_width, model_icon_height)
-		model_icon:SetEnabled(false)
-		model_icon:SetCursor("arrow")
-		model_icon:SetModel(model)
-		grid:AddItem(model_icon)
+	menu.AddModel = function (model)
+		local modelIcon = vgui.Create("SpawnIcon")
+		modelIcon:SetPos(75, 75)
+		modelIcon:SetSize(modelIconWidth, modelIconHeight)
+		modelIcon:SetEnabled(false)
+		modelIcon:SetCursor("arrow")
+		modelIcon:SetModel(model)
+		grid:AddItem(modelIcon)
 
-		local unban_button = vgui.Create("DButton", model_icon)
-		unban_button:SetSize(model_icon_width, model_icon_height / 4)
-		unban_button:SetText("Unban Model")
-		unban_button:SetPos(0, model_icon_height - unban_button:GetTall())
-		unban_button:SetVisible(false)
+		local unbanButton = vgui.Create("DButton", modelIcon)
+		unbanButton:SetSize(modelIconWidth, modelIconHeight / 4)
+		unbanButton:SetText("Unban Model")
+		unbanButton:SetPos(0, modelIconHeight - unbanButton:GetTall())
+		unbanButton:SetVisible(false)
 
 		-- What to do when the unban button for a model is clicked.
-		function unban_button:DoClick()
+		function unbanButton:DoClick()
 			-- This client side check is for informational purposes.
 			if !LocalPlayer():IsAdmin() then
 				chat.AddText(Color(255, 50, 50), "You must be an admin to edit the banned models list.")
@@ -169,13 +167,13 @@ function GM:CreateBannedModelsMenu()
 		end
 
 		-- Logic for showing/hiding the unban button.
-		function model_icon:Think()
+		function modelIcon:Think()
 			self:GetChild(1):SetVisible(LocalPlayer():IsAdmin() && (self:IsHovered() || self:IsChildHovered()))
 		end
 	end
 
 	-- Same as menu.AddModel but for removing models from the grid.
-	menu.RemoveModel = function(model)
+	menu.RemoveModel = function (model)
 		for _, value in pairs(menu.grid:GetItems()) do
 			if value:GetModelName() == model then
 				menu.grid:RemoveItem(value)

--- a/gamemode/cl_bannedmodels.lua
+++ b/gamemode/cl_bannedmodels.lua
@@ -1,147 +1,186 @@
-GM.BannedModels = {}
+-- This file provides the functionality for accessing the banned models
+-- menu. It is used locally to determine if a model is viable (aka
+-- whether or not it gets an outline when moused over).
+
+
+GM.BannedModels = {} -- This is used as a hash table where the key is the model string and the value is true.
+local menu
+
 
 function GM:IsModelBanned(model)
-	return table.HasValue(self.BannedModels, model)
+	return self.BannedModels[model] == true
 end
+
 
 function GM:AddBannedModel(model)
-	table.insert(self.BannedModels, model)
+	if self.BannedModels[model] == true then return end -- Prevent duplicates.
+
+	self.BannedModels[model] = true
+	menu.AddModel(model)
 end
+
 
 function GM:RemoveBannedModel(model)
-	table.RemoveByValue(self.BannedModels, model)
+	if self.BannedModels[model] != true then return end -- Check if exists before trying to remove.
+
+	self.BannedModels[model] = nil
+	menu.RemoveModel(model)
 end
 
-function GM:GetBannedModels()
-	return self.BannedModels
-end
 
-net.Receive("ph_bannedmodels", function (len)
+net.Receive("ph_bannedmodels_getall", function (len)
 	GAMEMODE.BannedModels = {}
 
-	while true do
-		local k = net.ReadUInt(16)
-		if k == 0 then
-			break
-		end
-		local v = net.ReadString()
-		GAMEMODE.BannedModels[k] = v
+	local banned_model = net.ReadString()
+	while banned_model != "" do
+		GAMEMODE:AddBannedModel(banned_model)
+		banned_model = net.ReadString()
 	end
 end)
 
-local menu
+
+net.Receive("ph_bannedmodels_add", function (len)
+	local v = net.ReadString()
+	GAMEMODE:AddBannedModel(v)
+end)
+
+
+net.Receive("ph_bannedmodels_remove", function (len)
+	local v = net.ReadString()
+	GAMEMODE:RemoveBannedModel(v)
+end)
+
+
 concommand.Add("ph_bannedmodels_menu", function (client)
-	if !client:IsSuperAdmin() then
-		if IsValid(menu) then
-			menu:Remove()
-		end
-		return
-	end
-	if IsValid(menu) then
-		menu:SetVisible(true)
-		net.Start("ph_bannedmodels")
-		net.SendToServer()
-		return
-	end
+	menu:SetVisible(true)
+end)
 
-	-- GAMEMODE.BannedModels = {"asd/models.ad"}
 
+-- This is all the code to create the banned models menu.
+-- TODO: I don't like adding this to GM. I feel like there should absolutely be a better solution.
+function GM:CreateBannedModelsMenu()
+	-- The main window that will contain all of the functionality for display, adding, and
+	-- removing banned models.
 	menu = vgui.Create("DFrame")
+	menu:SetPos(200, 200)
 	menu:SetSize(ScrW() * 0.4, ScrH() * 0.8)
 	menu:SetTitle("Banned Models")
 	menu:Center()
+	menu:SetDraggable(true)
+	menu:ShowCloseButton(true)
 	menu:MakePopup()
+	menu:SetDeleteOnClose(false)
+	menu:SetVisible(false)
 
-	local mlist = vgui.Create("DScrollPanel", menu)
-	mlist:Dock(FILL)
-
-	local canvas = mlist:GetCanvas()
-	canvas:DockPadding(0, 0, 0, 0)
-	function canvas:OnChildAdded( child )
-		child:Dock(TOP)
+	-- Create a text box at the top of the window so the player can input new banned models.
+	local entry = vgui.Create("DTextEntry", menu)
+	entry:Dock(TOP)
+	if LocalPlayer():IsAdmin() then
+		entry:SetPlaceholderText("Hover for usage information.")
+		entry:SetTooltip([[
+			To ban a model from usage put the path
+			to the model into this text box and
+			press Enter.
+			EXAMPLE INPUTS
+			models/props/cs_assault/money.mdl
+			models/props_borealis/bluebarrel001.mdl
+			models/props/cs_office/projector_remote.mdl]])
+	else
+		entry:SetPlaceholderText("You must be an admin to ban models.")
+		entry:SetTooltip("You must be an admin to ban models.")
+		entry:SetEnabled(false)
 	end
 
-	local but = vgui.Create("DButton")
-	but:SetText("")
-	but:Dock(TOP)
-
-	function but:PerformLayout()
-		local c = 0
-		for k, v in pairs(GAMEMODE.BannedModels) do
-			c = c + 1
+	-- What to do when the ENTER key is pressed on the text box.
+	function entry:OnEnter()
+		-- This client side check is for informational purposes.
+		if !LocalPlayer():IsAdmin() then
+			chat.AddText(Color(255, 50, 50), "You must be an admin to edit the banned models list.")
+			return
 		end
-		c = c + 2
-		self:SetTall(c * 20 + 8)
+
+		local model_to_ban = entry:GetText()
+		-- This client side check is for informational purposes.
+		if string.len(model_to_ban) == 0 then
+			chat.AddText(Color(255, 50, 50), "Error when attempting to ban model: no input text was given.")
+			return
+		end
+		-- This client side check is for informational purposes.
+		if GAMEMODE:IsModelBanned(model_to_ban) then
+			chat.AddText(Color(255, 50, 50), "That model is already banned.")
+			return
+		end
+
+		net.Start("ph_bannedmodels_add")
+		net.WriteString(model_to_ban)
+		net.SendToServer()
+		entry:SetText("")
 	end
 
-	local icon = Material("icon16/cross.png")
-	function but:Paint(w, h)
-		-- surface.SetDrawColor(50, 50, 50)
-		-- surface.DrawRect(0, 0, w, h)
+	-- Makes a scroll bar on the right side in the event that there are a LOT of
+	-- banned models and we need to be able to scroll. Will not appear unless
+	-- there are enough items in the list to require it.
+	local scroll_panel = vgui.Create("DScrollPanel", menu)
+	scroll_panel:Dock(FILL)
+	
+	local model_icon_width = 128
+	local model_icon_height = 128
+	local usable_width_for_model_icons = menu:GetWide() - scroll_panel:GetVBar():GetWide() -- Don't want icons to overlap the scroll bar.
+	local num_cols = math.floor(usable_width_for_model_icons / model_icon_width)
+	-- This offset is almost right, but there's 10 pixels more on the left than on the right and I can't figure out why. :(
+	local left_offset = (usable_width_for_model_icons - (model_icon_width * num_cols)) / 2
 
-		surface.SetMaterial(icon)
+	-- This is the grid that will give the icons a nice layout.
+	local grid = vgui.Create("DGrid", scroll_panel)
+	menu.grid = grid
+	grid:SetCols(num_cols)
+	grid:SetPos(left_offset, 10)
+	grid:SetColWide(model_icon_width)
+	grid:SetRowHeight(model_icon_height)
 
-		local mx, my = gui.MousePos()
-		local sx, sy = self:LocalToScreen(0, 0)
-		local s
-		if mx >= sx + w - 16 - 4 && mx < sx + w - 4 then
-			sx = mx - sx - 4
-			sy = my - sy - 4
-			s = math.floor(sy / 20)
-		end
+	-- Allows functions outside of the menu to update the icons. Useful for updating the menu
+	-- live if it's open when a net message is received to add a model.
+	menu.AddModel = function(model)
+		local model_icon = vgui.Create("SpawnIcon")
+		model_icon:SetPos(75, 75)
+		model_icon:SetSize(model_icon_width, model_icon_height)
+		model_icon:SetEnabled(false)
+		model_icon:SetCursor("arrow")
+		model_icon:SetModel(model)
+		grid:AddItem(model_icon)
 
-		local c = 0
-		for k, v in pairs(GAMEMODE.BannedModels) do
+		local unban_button = vgui.Create("DButton", model_icon)
+		unban_button:SetSize(model_icon_width, model_icon_height / 4)
+		unban_button:SetText("Unban Model")
+		unban_button:SetPos(0, model_icon_height - unban_button:GetTall())
+		unban_button:SetVisible(false)
 
-			draw.SimpleText(v, "RobotoHUD-L15", 4, 4 + c * 20, color_white, 0)
-			if s == c then
-				surface.SetDrawColor(50, 50, 50)
-			else
-				surface.SetDrawColor(255, 255, 255)
+		-- What to do when the unban button for a model is clicked.
+		function unban_button:DoClick()
+			-- This client side check is for informational purposes.
+			if !LocalPlayer():IsAdmin() then
+				chat.AddText(Color(255, 50, 50), "You must be an admin to edit the banned models list.")
+				return
 			end
-			surface.DrawTexturedRect(w - 16 - 4, c * 20 + 6, 16, 16)
 
-			c = c + 1
+			net.Start("ph_bannedmodels_remove")
+			net.WriteString(self:GetParent():GetModelName())
+			net.SendToServer()
+		end
+
+		-- Logic for showing/hiding the unban button.
+		function model_icon:Think()
+			self:GetChild(1):SetVisible(LocalPlayer():IsAdmin() && (self:IsHovered() || self:IsChildHovered()))
 		end
 	end
 
-	function but:DoClick()
-		local w, h = self:GetSize()
-
-		local mx, my = gui.MousePos()
-		local sx, sy = self:LocalToScreen(0, 0)
-		local s
-		if mx >= sx + w - 16 - 4 && mx < sx + w - 4 then
-			sx = mx - sx - 4
-			sy = my - sy - 4
-			s = math.floor(sy / 20)
-		end
-
-		local c = 0
-		for k, v in pairs(GAMEMODE.BannedModels) do
-			if s == c then
-				RunConsoleCommand("ph_bannedmodels_remove", v)
-				net.Start("ph_bannedmodels")
-				net.SendToServer()
+	-- Same as menu.AddModel but for removing models from the grid.
+	menu.RemoveModel = function(model)
+		for _, value in pairs(menu.grid:GetItems()) do
+			if value:GetModelName() == model then
+				menu.grid:RemoveItem(value)
 				break
 			end
-			c = c + 1
 		end
 	end
-
-	mlist:AddItem(but)
-	mlist:InvalidateLayout()
-
-	local entry = vgui.Create("DTextEntry", menu)
-	entry:Dock(BOTTOM)
-
-	function entry:OnEnter()
-		RunConsoleCommand("ph_bannedmodels_add", entry:GetValue())
-		entry:SetText("")
-		net.Start("ph_bannedmodels")
-		net.SendToServer()
-	end
-
-	net.Start("ph_bannedmodels")
-	net.SendToServer()
-end)
+end

--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -20,6 +20,11 @@ include("cl_bannedmodels.lua")
 function GM:InitPostEntity()
 	net.Start("clientIPE")
 	net.SendToServer()
+
+	-- Sync the banned models
+	self:CreateBannedModelsMenu()
+	net.Start("ph_bannedmodels_getall")
+	net.SendToServer()
 end
 
 function GM:PostDrawViewModel( vm, ply, weapon )

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -72,7 +72,6 @@ function GM:InitPostEntity()
 end
 
 function GM:InitPostEntityAndMapCleanup() 
-	self:RemoveBannedModelProps()
 	for k, ent in pairs(ents.GetAll()) do
 		if ent:GetClass():find("door") then
 			ent:Fire("unlock","",0)

--- a/gamemode/sh_disguise.lua
+++ b/gamemode/sh_disguise.lua
@@ -123,6 +123,8 @@ function GM:PlayerCanDisguiseCurrentTarget(ply)
 	if ply:Team() == 3 then
 		local tr = ply:GetPropEyeTrace()
 		if IsValid(tr.Entity) then
+			if(self:IsModelBanned(tr.Entity:GetModel())) then return false, nil end
+
 			local testPos = Vector(tr.StartPos.x, tr.StartPos.y, 0)
 			local hitPosition = Vector(tr.HitPos.x, tr.HitPos.y, 0)
 			local hitZ = tr.HitPos.z

--- a/gamemode/sh_disguise.lua
+++ b/gamemode/sh_disguise.lua
@@ -123,7 +123,7 @@ function GM:PlayerCanDisguiseCurrentTarget(ply)
 	if ply:Team() == 3 then
 		local tr = ply:GetPropEyeTrace()
 		if IsValid(tr.Entity) then
-			if(self:IsModelBanned(tr.Entity:GetModel())) then return false, nil end
+			if self:IsModelBanned(tr.Entity:GetModel()) then return false, nil end
 
 			local testPos = Vector(tr.StartPos.x, tr.StartPos.y, 0)
 			local hitPosition = Vector(tr.HitPos.x, tr.HitPos.y, 0)

--- a/gamemode/sv_bannedmodels.lua
+++ b/gamemode/sv_bannedmodels.lua
@@ -16,12 +16,16 @@ end
 
 
 function GM:AddBannedModel(model)
+	if self.BannedModels[model] == true then return end
+
 	self.BannedModels[model] = true
 	self:SaveBannedModels()
 end
 
 
 function GM:RemoveBannedModel(model)
+	if self.BannedModels[model] != true then return end
+
 	self.BannedModels[model] = nil
 	self:SaveBannedModels()
 end

--- a/gamemode/sv_bannedmodels.lua
+++ b/gamemode/sv_bannedmodels.lua
@@ -1,102 +1,110 @@
-GM.BannedModels = {}
+-- This file is what controls what models are banned. Models that are banned
+-- cannot be chosen as a disguise.
 
-util.AddNetworkString("ph_bannedmodels")
+
+GM.BannedModels = {} -- This is used as a hash table where the key is the model string and the value is true.
+
+
+util.AddNetworkString("ph_bannedmodels_getall")
+util.AddNetworkString("ph_bannedmodels_add")
+util.AddNetworkString("ph_bannedmodels_remove")
+
 
 function GM:IsModelBanned(model)
-	return table.HasValue(self.BannedModels, model)
+	return self.BannedModels[model] == true
 end
+
 
 function GM:AddBannedModel(model)
-	table.insert(self.BannedModels, model)
+	if self.BannedModels[model] == true then return end -- Prevent duplicates.
+
+	self.BannedModels[model] = true
 	self:SaveBannedModels()
-	self:RemoveBannedModelProps()
 end
+
 
 function GM:RemoveBannedModel(model)
-	table.RemoveByValue(self.BannedModels, model)
+	if self.BannedModels[model] != true then return end -- Check if exists before trying to remove.
+
+	self.BannedModels[model] = nil
 	self:SaveBannedModels()
 end
 
-function GM:GetBannedModels()
-	return self.BannedModels
-end
 
 function GM:SaveBannedModels()
-	// ensure the folders are there
+	-- ensure the folders are there
 	if !file.Exists("husklesph/","DATA") then
 		file.CreateDir("husklesph")
 	end
 
 	local txt = ""
-	for k, v in pairs(self.BannedModels) do
-		txt = txt .. v .. "\r\n"
+	for key, value in pairs(self.BannedModels) do
+		if value then
+			txt = txt .. key .. "\r\n"
+		end
 	end
 	file.Write("husklesph/bannedmodels.txt", txt)
 end
 
-function GM:LoadBannedModels() 
-	local jason = file.ReadDataAndContent("husklesph/bannedmodels.txt")
-	if jason then
+
+function GM:LoadBannedModels()
+	local banned_models = file.Read("husklesph/bannedmodels.txt", "DATA")
+	if banned_models then
 		local tbl = {}
-		for map in jason:gmatch("[^\r\n]+") do
-			table.insert(tbl, map)
-		end
-		self.BannedModels = tbl
-	else
-
-		// don't touch this
-		// use ph_bannedmodels_menu or edit data/husklesph/bannedmodels.txt
-		self.BannedModels = {
-			"models/props/cs_assault/money.mdl",
-			"models/props/cs_office/computer_mouse.mdl",
-			"models/props/cs_office/projector_remote.mdl"
-		}
-	end
-end
-
-function GM:RemoveBannedModelProps()
-	for k, ent in pairs(ents.GetAll()) do
-		if IsValid(ent) && ent:IsDisguisableAs() then
-			if self:IsModelBanned(ent:GetModel()) then
-				ent:Remove()
-			end
+		for match in banned_models:gmatch("[^\r\n]+") do
+			self:AddBannedModel(match)
 		end
 	end
 end
 
-net.Receive("ph_bannedmodels", function (len, ply)
-	if ply.BannedAntiSpam && ply.BannedAntiSpam > CurTime() then return end
-	ply.BannedAntiSpam = CurTime() + 0.1
 
-	net.Start("ph_bannedmodels")
-	for k, v in pairs(GAMEMODE.BannedModels) do
-		net.WriteUInt(k, 16)
-		net.WriteString(tostring(v))
+net.Receive("ph_bannedmodels_getall", function (len, ply)
+	-- This section is to prevent this particular net.Receive from going into an infinite loop.
+	if ply.PHBannedModelsGetAllCooldown != nil && ply.PHBannedModelsGetAllCooldown > CurTime() then return end
+	ply.PHBannedModelsGetAllCooldown = CurTime() + 0.1
+
+	net.Start("ph_bannedmodels_getall")
+
+	for key, value in pairs(GAMEMODE.BannedModels) do
+		if value then
+			net.WriteString(key)
+		end
 	end
-	net.WriteUInt(0, 16)
+
+	net.WriteString("")
 	net.Send(ply)
 end)
 
-concommand.Add("ph_bannedmodels_add", function (ply, com, args)
-	if !ply:IsSuperAdmin() then
-		ply:ChatPrint("Not a superadmin")
-		return
-	end
-	if #args < 1 then
-		ply:ChatPrint("Too few arguments")
-		return
-	end
-	GAMEMODE:AddBannedModel(args[1])
+
+net.Receive("ph_bannedmodels_add", function (len, ply)
+	-- This section is to prevent this particular net.Receive from going into an infinite loop.
+	if ply.PHBannedModelsAddCooldown != nil && ply.PHBannedModelsAddCooldown > CurTime() then return end
+	ply.PHBannedModelsAddCooldown = CurTime() + 0.1
+
+	if !ply:IsAdmin() then return end -- Only admins can change the banned models list.
+
+	local model_to_ban = net.ReadString()
+	if string.len(model_to_ban) == 0 then return end -- Don't add empty strings.
+
+	GAMEMODE:AddBannedModel(model_to_ban)
+	net.Start("ph_bannedmodels_add")
+	net.WriteString(model_to_ban)
+	net.Broadcast()
 end)
 
-concommand.Add("ph_bannedmodels_remove", function (ply, com, args)
-	if !ply:IsSuperAdmin() then
-		ply:ChatPrint("Not a superadmin")
-		return
-	end
-	if #args < 1 then
-		ply:ChatPrint("Too few arguments")
-		return
-	end
-	GAMEMODE:RemoveBannedModel(args[1])
+
+net.Receive("ph_bannedmodels_remove", function (len, ply)
+	-- This section is to prevent this particular net.Receive from going into an infinite loop.
+	if ply.PHBannedModelsRemoveCooldown != nil && ply.PHBannedModelsRemoveCooldown > CurTime() then return end
+	ply.PHBannedModelsRemoveCooldown = CurTime() + 0.1
+
+	if !ply:IsAdmin() then return end -- Only admins can change the banned models list.
+
+	local model_to_unban = net.ReadString()
+	if string.len(model_to_unban) == 0 then return end -- Don't try to remove empty strings.
+
+	GAMEMODE:RemoveBannedModel(model_to_unban)
+	net.Start("ph_bannedmodels_remove")
+	net.WriteString(model_to_unban)
+	net.Broadcast()
 end)


### PR DESCRIPTION
Props that are banned are no longer completely removed from the map.
Instead they are left in the map but are not highlighted as valid
objects to change into if the player mouses over the prop.

The ph_bannedmodels_menu has been completely reworked.
- Banned props are now shown as an icon of their models instead of a
  line of text of their model string.
- If you are an admin you can hover over a prop icon and get a button to
  unban that particular prop. There is also a text field to ban new
  props at the top of the menu.
- Unbanned props become available to change into as soon as the same
  round in which they are unbanned. The same logic applies to props that
  are banned.
- The banned models menu now updates live. This allows multiple players to have 
  the menu open at the same time and see changes made to the list immediately.

This will break anything that relied on editing the banned props list via the console commands ph_bannedmodels_add and ph_bannedmodels_remove. The solution is to either use the husklesph/bannedmodels.txt data file or the net messages.