### PR TITLE
Fixed incorrect version check url

### DIFF
--- a/gamemode/sv_version.lua
+++ b/gamemode/sv_version.lua
@@ -1,4 +1,4 @@
-local url = "https://raw.githubusercontent.com/zikaeroh/husklesph/master/prophunters.txt"
+local url = "https://raw.githubusercontent.com/zikaeroh/husklesph/master/husklesph.txt"
 local downloadlinks = "https://steamcommunity.com/sharedfiles/filedetails/?id=1585255351"
 
 


### PR DESCRIPTION
The current version check uses the wrong url and gives a 404 response when the gamemode tries to check if it is up-to-date.