### PR TITLE
Added map time limit config option

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -45,6 +45,7 @@ GM.PropsSmallSize = CreateConVar("ph_props_small_size", 200, bit.bor(FCVAR_NOTIF
 GM.PropsJumpPower = CreateConVar("ph_props_jumppower", 1.2, bit.bor(FCVAR_NOTIFY), "Jump power bonus for when props are disguised" )
 GM.PropsCamDistance = CreateConVar("ph_props_camdistance", 1, bit.bor(FCVAR_NOTIFY), "The camera distance multiplier for props when disguised")
 GM.TauntMenuPhrase = CreateConVar("ph_taunt_menu_phrase", TauntMenuPhrase, bit.bor(FCVAR_NOTIFY), "Phrase shown at the top of the taunt menu")
+GM.MapTimeLimit = CreateConVar("ph_map_time_limit", -1, bit.bor(FCVAR_NOTIFY), "Minutes before declaring the next round to be the last round (-1 to disable)")
 
 GM.AutoTauntEnabled = CreateConVar("ph_auto_taunt", 0, bit.bor(FCVAR_NOTIFY), "1 if auto taunts should be enabled")
 GM.AutoTauntMin = CreateConVar("ph_auto_taunt_delay_min", 60, bit.bor(FCVAR_NOTIFY), "Mininum time to go without taunting")


### PR DESCRIPTION
Added a new convar `ph_map_time_limit`.
This convar should be set to either a positive integer or -1. A positive integer will enable the timer while a value of -1 will disable the timer. The timer is disabled by default.

If a positive integer is given it will be interpreted as the number of minutes a map should last. When the timer expires it will make the **following** round be the last round. The reason it does the following round instead of the current round is so that we're not letting people know in the middle of a round that their current round will be the last one.

This new option can coexist with the `ph_roundlimit` convar. You can have the map end after a certain number of rounds have passed or after a certain amount of time has passed.

Added a chat message that appears when the current round will be the last round (the message will indicate as much).