### PR TITLE
Add utility stuff

### DIFF
--- a/gamemodes/husklesph/gamemode/cl_disguise.lua
+++ b/gamemodes/husklesph/gamemode/cl_disguise.lua
@@ -51,7 +51,7 @@ end
 
 function GM:RenderDisguiseHalo()
 	local client = LocalPlayer()
-	if client:Team() == 3 then
+	if client:IsProp() then
 		local canDisguise, target = self:PlayerCanDisguiseCurrentTarget(client)
 		if canDisguise then
 			local col = Color(50, 220, 50)
@@ -64,12 +64,12 @@ function GM:RenderDisguiseHalo()
 
 		local tab = {}
 		for k, ply in pairs(player.GetAll()) do
-			if ply != client && ply:Team() == 3 && ply:IsDisguised() then
+			if ply != client && ply:IsProp() && ply:IsDisguised() then
 				if IsValid(ply.PropMod) then
 					table.insert(tab, ply.PropMod)
 				end
 			end
 		end
-		halo.Add(tab, team.GetColor(3), 2, 2, 2, true, false)
+		halo.Add(tab, team.GetColor(TEAM_PROP), 2, 2, 2, true, false)
 	end
 end

--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -341,7 +341,7 @@ function GM:OpenEndRoundMenu()
 	winner:DockMargin(20, 20, 20, 20)
 	winner:SetTall(draw.GetFontHeight("RobotoHUD-45"))
 	winner:SetText("Props win!")
-	winner:SetColor(team.GetColor(3))
+	winner:SetColor(team.GetColor(TEAM_PROP))
 	winner:SetFont("RobotoHUD-45")
 
 	local timeleft = vgui.Create("DPanel", respnl)
@@ -349,7 +349,7 @@ function GM:OpenEndRoundMenu()
 	timeleft:SetTall(draw.GetFontHeight("RobotoHUD-20"))
 	local col = Color(150, 150, 150)
 	function timeleft:Paint(w, h)
-		if GAMEMODE:GetGameState() == 3 then
+		if GAMEMODE:GetGameState() == ROUND_POST then
 			local settings = GAMEMODE:GetRoundSettings()
 			local roundTime = settings.NextRoundTime || 30
 			local time = math.max(0, roundTime - GAMEMODE:GetStateRunningTime())
@@ -396,7 +396,7 @@ function GM:OpenEndRoundMenu()
 	timeleft:SetTall(draw.GetFontHeight("RobotoHUD-20"))
 	local col = Color(150, 150, 150)
 	function timeleft:Paint(w, h)
-		if GAMEMODE:GetGameState() == 4 then
+		if GAMEMODE:GetGameState() == ROUND_MAPVOTE then
 			local voteTime = GAMEMODE.MapVoteTime || 30
 			local time = math.max(0, voteTime - GAMEMODE:GetMapVoteRunningTime())
 			draw.SimpleText("Voting ends in " .. math.ceil(time), "RobotoHUD-20", w - 4, 0, col, 2)
@@ -463,7 +463,7 @@ function GM:EndRoundMenuResults(res)
 	menu.Results = res
 	menu.ChatList:Clear()
 	menu.ResultList:Clear()
-	if res.reason == 2 || res.reason == 3 then
+	if res.reason == WIN_HUNTER || res.reason == WIN_PROP then
 		menu.WinningTeam:SetText(team.GetName(res.reason) .. " win!")
 		menu.WinningTeam:SetColor(team.GetColor(res.reason))
 	else

--- a/gamemodes/husklesph/gamemode/cl_hud.lua
+++ b/gamemodes/husklesph/gamemode/cl_hud.lua
@@ -67,7 +67,7 @@ function GM:DrawGameHUD()
 		-- draw names
 		if IsValid(tr.Entity) && tr.Entity:IsPlayer() && tr.HitPos:Distance(tr.StartPos) < 500 then
 			-- hunters can only see their teams names
-			if ply:Team() != 2 || ply:Team() == tr.Entity:Team() then
+			if !ply:IsHunter() || ply:Team() == tr.Entity:Team() then
 				self.LastLooked = tr.Entity
 				self.LookedFade = CurTime()
 			end
@@ -83,8 +83,8 @@ function GM:DrawGameHUD()
 
 	local help
 	if LocalPlayer():Alive() then
-		if LocalPlayer():Team() == 3 then
-			if self:GetGameState() == 1 || (self:GetGameState() == 2 && !LocalPlayer():IsDisguised()) then
+		if LocalPlayer():IsProp() then
+			if self:GetGameState() == ROUND_HIDE || (self:GetGameState() == ROUND_SEEK && !LocalPlayer():IsDisguised()) then
 				help = helpKeysProps
 			end
 		end
@@ -236,19 +236,19 @@ function GM:HUDShouldDraw(name)
 end
 
 function GM:DrawRoundTimer()
-	if self:GetGameState() == 0 then
+	if self:GetGameState() == ROUND_WAIT then
 		local time = math.ceil(self.StartWaitTime:GetFloat() - self:GetStateRunningTime())
 		if time > 0 then
 			draw.ShadowText("Waiting for players to join", "RobotoHUD-25", ScrW() / 2, ScrH() / 10 - draw.GetFontHeight("RobotoHUD-40") / 4, color_white, 1, 4)
 			draw.ShadowText("Game starts in " .. tostring(time) .. " second" .. (time > 1 && "s" || ""), "RobotoHUD-15", ScrW() / 2, ScrH() / 10, color_white, 1, 1)
 		end
-	elseif self:GetGameState() == 1 then
+	elseif self:GetGameState() == ROUND_HIDE then
 		local time = math.ceil(30 - self:GetStateRunningTime())
 		if time > 0 then
 			draw.ShadowText("Hunters will be released in", "RobotoHUD-15", ScrW() / 2, ScrH() / 3 - draw.GetFontHeight("RobotoHUD-40") / 2, color_white, 1, 4)
 			draw.ShadowText(time, "RobotoHUD-40", ScrW() / 2, ScrH() / 3, color_white, 1, 1)
 		end
-	elseif self:GetGameState() == 2 then
+	elseif self:GetGameState() == ROUND_SEEK then
 		if self:GetStateRunningTime() < 2 then
 			draw.ShadowText("GO!", "RobotoHUD-50", ScrW() / 2, ScrH() / 3, color_white, 1, 1)
 		end
@@ -267,8 +267,8 @@ end
 
 function GM:PreDrawHUD()
 	local client = LocalPlayer()
-	if self:GetGameState() == 1 then
-		if client:Team() == 2 then
+	if self:GetGameState() == ROUND_HIDE then
+		if client:IsHunter() then
 			surface.SetDrawColor(25, 25, 25, 255)
 			surface.DrawRect(-10, -10, ScrW() + 20, ScrH() + 20)
 		end

--- a/gamemodes/husklesph/gamemode/cl_rounds.lua
+++ b/gamemodes/husklesph/gamemode/cl_rounds.lua
@@ -1,4 +1,4 @@
-GM.GameState = GAMEMODE && GAMEMODE.GameState || 0
+GM.GameState = GAMEMODE && GAMEMODE.GameState || ROUND_WAIT
 GM.StateStart = GAMEMODE && GAMEMODE.StateStart || CurTime()
 
 function GM:GetGameState()
@@ -17,12 +17,12 @@ net.Receive("gamestate", function(len)
 	GAMEMODE.GameState = net.ReadUInt(32)
 	GAMEMODE.StateStart = net.ReadDouble()
 
-	if GAMEMODE.GameState == 1 then
+	if GAMEMODE.GameState == ROUND_HIDE then
 		GAMEMODE.UpgradesNotif = {}
 		GAMEMODE.KillFeed = {}
 	end
 
-	if GAMEMODE.GameState != 2 then
+	if GAMEMODE.GameState != ROUND_SEEK then
 		GAMEMODE:CloseEndRoundMenu()
 	end
 end)
@@ -30,7 +30,7 @@ end)
 net.Receive("round_victor", function(len)
 	local tab = {}
 	tab.reason = net.ReadUInt(8)
-	if tab.reason == 2 || tab.reason == 3 then
+	if tab.reason == WIN_HUNTER || tab.reason == WIN_PROP then
 		tab.winningTeam = net.ReadUInt(16)
 	end
 

--- a/gamemodes/husklesph/gamemode/cl_scoreboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_scoreboard.lua
@@ -212,7 +212,7 @@ end
 
 function GM:ScoreboardShow()
 	if IsValid(menu) then
-		if GAMEMODE.GameState == 3 then
+		if GAMEMODE.GameState == ROUND_POST then
 			menu:SetVisible(false)
 		else
 			menu:SetVisible(true)
@@ -268,7 +268,7 @@ function GM:ScoreboardShow()
 
 		function bottom:Paint(w, h)
 			local c
-			for k, ply in pairs(team.GetPlayers(1)) do
+			for k, ply in pairs(team.GetPlayers(TEAM_SPEC)) do
 				if c then
 					c = c .. ", " .. ply:Nick()
 				else
@@ -300,7 +300,7 @@ function GM:ScoreboardShow()
 			draw.ShadowText("Spectate", "RobotoHUD-15", w / 2, h / 2, colt, 1, 1)
 		end
 		function but:DoClick()
-			RunConsoleCommand("car_jointeam", 1)
+			RunConsoleCommand("car_jointeam", TEAM_SPEC)
 		end
 
 		local main = vgui.Create("DPanel", menu)
@@ -310,17 +310,17 @@ function GM:ScoreboardShow()
 			-- surface.DrawRect(0, 0, w, h)
 		end
 
-		menu.CopsList = makeTeamList(main, 2)
+		menu.CopsList = makeTeamList(main, TEAM_HUNTER)
 		menu.CopsList:Dock(LEFT)
 		menu.CopsList:DockMargin(0, 0, 8, 0)
-		menu.RobbersList = makeTeamList(main, 3)
+		menu.RobbersList = makeTeamList(main, TEAM_PROP)
 		menu.RobbersList:Dock(FILL)
 
 
 	end
 end
 function GM:ScoreboardHide()
-	if GAMEMODE.GameState == 3 then
+	if GAMEMODE.GameState == ROUND_POST then
 		menu:Close()
 		return
 	end

--- a/gamemodes/husklesph/gamemode/init.lua
+++ b/gamemodes/husklesph/gamemode/init.lua
@@ -103,7 +103,7 @@ function GM:EntityTakeDamage( ent, dmginfo )
 		end
 		if ent:IsDisguisableAs() then
 			local att = dmginfo:GetAttacker()
-			if IsValid(att) && att:IsPlayer() && att:Team() == 2 then
+			if IsValid(att) && att:IsPlayer() && att:IsHunter() then
 
 				if bit.band(dmginfo:GetDamageType(), DMG_CRUSH) != DMG_CRUSH then
 					local tdmg = DamageInfo()

--- a/gamemodes/husklesph/gamemode/sh_disguise.lua
+++ b/gamemodes/husklesph/gamemode/sh_disguise.lua
@@ -5,7 +5,7 @@ local allowClasses = {"prop_physics", "prop_physics_multiplayer"}
 
 function PlayerMeta:CanDisguiseAsProp(ent)
 	if !self:Alive() then return false end
-	if self:Team() != 3 then return false end
+	if !self:IsProp() then return false end
 	if !IsValid(ent) then return false end
 
 	if !table.HasValue(allowClasses, ent:GetClass()) then
@@ -117,7 +117,7 @@ function GM:PlayerCanDisguiseCurrentTarget(ply)
 	local minHLeniency = 100
 	local verticalLeniency = 100
 
-	if ply:Team() == 3 then
+	if ply:IsProp() then
 		local tr = ply:GetPropEyeTrace()
 		if IsValid(tr.Entity) then
 			if self:IsModelBanned(tr.Entity:GetModel()) then return false, nil end

--- a/gamemodes/husklesph/gamemode/sh_taunt.lua
+++ b/gamemodes/husklesph/gamemode/sh_taunt.lua
@@ -35,9 +35,9 @@ end
 local function teamNameToNum(pteam)
 	pteam = pteam:lower()
 	if pteam == "prop" || pteam == "props" then
-		return 3
+		return TEAM_PROP
 	elseif pteam == "hunter" || pteam == "hunters" then
-		return 2
+		return TEAM_HUNTER
 	end
 	return nil
 end

--- a/gamemodes/husklesph/gamemode/shared.lua
+++ b/gamemodes/husklesph/gamemode/shared.lua
@@ -1,3 +1,4 @@
+local PlayerMeta = FindMetaTable("Player")
 local tabFile = file.Read(GM.Folder .. "/husklesph.txt", "GAME") || ""
 local tab = util.KeyValuesToTable(tabFile)
 
@@ -8,11 +9,34 @@ GM.Email 	= "N/A"
 GM.Website 	= "N/A"
 GM.Version  = tab["version"] || "unknown"
 
+
+ROUND_WAIT = 1
+ROUND_HIDE = 2
+ROUND_SEEK = 3
+ROUND_POST = 4
+ROUND_MAPVOTE = 5
+
+
+TEAM_SPEC = 1
+TEAM_HUNTER = 2
+TEAM_PROP = 3
+
+
+WIN_NONE = TEAM_SPEC
+WIN_HUNTER = TEAM_HUNTER
+WIN_PROP = TEAM_PROP
+
+
+function PlayerMeta:IsSpectator() return self:Team() == TEAM_SPEC end
+function PlayerMeta:IsHunter() return self:Team() == TEAM_HUNTER end
+function PlayerMeta:IsProp() return self:Team() == TEAM_PROP end
+
+
 GM.StartWaitTime = CreateConVar("ph_mapstartwait", 30, bit.bor(FCVAR_NOTIFY, FCVAR_REPLICATED), "Number of seconds to wait for players on map start before starting round" )
 
-team.SetUp(1, "Spectators", Color(120, 120, 120))
-team.SetUp(2, "Hunters", Color(255, 150, 50))
-team.SetUp(3, "Props", Color(50, 150, 255))
+team.SetUp(TEAM_SPEC, "Spectators", Color(120, 120, 120))
+team.SetUp(TEAM_HUNTER, "Hunters", Color(255, 150, 50))
+team.SetUp(TEAM_PROP, "Props", Color(50, 150, 255))
 
 function GM:PlayerSetNewHull(ply, s, hullz, duckz)
 	self:PlayerSetHull(ply, s, s, hullz, duckz)

--- a/gamemodes/husklesph/gamemode/sv_mapvote.lua
+++ b/gamemodes/husklesph/gamemode/sv_mapvote.lua
@@ -38,7 +38,7 @@ end
 function GM:ChangeMapTo(map)
 	if map == game.GetMap() then
 		self.Rounds = 0
-		self:SetGameState(0)
+		self:SetGameState(ROUND_WAIT)
 		return
 	end
 	print("[husklesph] Rotate changing map to " .. map)
@@ -120,7 +120,7 @@ function GM:StartMapVote()
 	-- MapVote Workshop Link: https://steamcommunity.com/sharedfiles/filedetails/?id=151583504
 	local initHookTbl = hook.GetTable().Initialize
 	if initHookTbl && initHookTbl.MapVoteConfigSetup then
-		self:SetGameState(4)
+		self:SetGameState(ROUND_MAPVOTE)
 		MapVote.Start()
 		return
 	end
@@ -144,7 +144,7 @@ function GM:StartMapVote()
 	-- 	end
 	-- end
 
-	self:SetGameState(4)
+	self:SetGameState(ROUND_MAPVOTE)
 	self:NetworkMapVoteStart()
 end
 
@@ -178,7 +178,7 @@ function GM:MapVoteThink()
 			else
 				GlobalChatMsg("Map change failed, not enough votes")
 				print("Map change failed, not enough votes")
-				self:SetGameState(0)
+				self:SetGameState(ROUND_WAIT)
 			end
 		end
 	end

--- a/gamemodes/husklesph/gamemode/sv_player.lua
+++ b/gamemodes/husklesph/gamemode/sv_player.lua
@@ -5,7 +5,7 @@ function GM:PlayerInitialSpawn(ply)
 
 	self:TeamsSetupPlayer(ply)
 
-	if self:GetGameState() != 0 then
+	if self:GetGameState() != ROUND_WAIT then
 		timer.Simple(0, function()
 			if IsValid(ply) then
 				ply:KillSilent()
@@ -32,7 +32,7 @@ net.Receive("clientIPE", function(len, ply)
 end)
 
 function GM:PlayerDisconnected(ply)
-	ply:SetTeam(2)
+	ply:SetTeam(TEAM_HUNTER)
 end
 
 util.AddNetworkString("hull_set")
@@ -137,7 +137,7 @@ function PlayerMeta:CalculateSpeed()
 end
 
 function GM:PlayerLoadout(ply)
-	if ply:Team() == 2 then
+	if ply:IsHunter() then
 		ply:Give("weapon_crowbar")
 		ply:Give("weapon_smg1")
 		ply:Give("weapon_shotgun")
@@ -246,7 +246,7 @@ end
 
 
 function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)
-	if !IsValid(ply) || ply:Team() == 1 then return true end
+	if !IsValid(ply) || ply:IsSpectator() then return true end
 	if !rigged && (!IsValid(spwn) || !spwn:IsInWorld()) then return false end
 
 	-- spwn is normally an ent, but we sometimes use a vector for jury rigged
@@ -258,7 +258,7 @@ function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)
 	local blocking = ents.FindInBox(pos + Vector( -32, -32, 0 ), pos + Vector( 32, 32, 64 )) -- Changed from (-16, -16, 0) (16, 16, 64)
 
 	for _, blockingEnt in ipairs(blocking) do
-		if IsValid(blockingEnt) && blockingEnt:IsPlayer() && blockingEnt:Team() != 1 && blockingEnt:Alive() then
+		if IsValid(blockingEnt) && blockingEnt:IsPlayer() && !blockingEnt:IsSpectator() && blockingEnt:Alive() then
 			if force then
 				blockingEnt:Kill()
 
@@ -297,9 +297,9 @@ local spectatorSpawnTypes = {"info_player_start", "gmod_player_start",
 
 local function getSpawnEnts(plyTeam, force_all)
 	local tblToUse
-	if plyTeam == 3 then
+	if plyTeam == TEAM_PROP then
 		tblToUse = propSpawnTypes
-	elseif plyTeam == 2 then
+	elseif plyTeam == TEAM_HUNTER then
 		tblToUse = hunterSpawnTypes
 	else
 		tblToUse = spectatorSpawnTypes
@@ -356,9 +356,6 @@ end
 
 function GM:PlayerSelectSpawn(ply)
 	local plyTeam = ply:Team()
-	-- 3 = Props
-	-- 2 = Hunters
-	-- 1 = Spectators
 
 	-- Should be true when the first player joins the game
 	if !self.SpawnPoints then
@@ -405,9 +402,9 @@ function GM:PlayerSelectSpawn(ply)
 		for _, rig in pairs(rigged) do
 			if self:IsSpawnpointSuitable(ply, rig, false, true) then
 				local spawnType
-				if ply:Team() == 3 then
+				if ply:IsProp() then
 					spawnType = "info_player_terrorist"
-				elseif ply:Team() == 2 then
+				elseif ply:IsHunter() then
 					spawnType = "info_player_counterterrorist"
 				else
 					spawnType = "info_player_start"
@@ -480,7 +477,7 @@ local function randomDeathsound(ply)
 end
 
 function GM:DoPlayerDeath(ply, attacker, dmginfo)
-	if ply:IsDisguised() && ply:Team() == 3 then
+	if ply:IsDisguised() && ply:IsProp() then
 		ply:EmitSound(randomDeathsound(ply))
 	end
 
@@ -495,7 +492,7 @@ function GM:DoPlayerDeath(ply, attacker, dmginfo)
 	ply.AutoTauntDeadline = nil
 
 	-- are they a prop
-	if ply:Team() == 3 then
+	if ply:IsProp() then
 		-- set the last death award
 		self.LastPropDeath = ply
 	end
@@ -519,7 +516,7 @@ function GM:DoPlayerDeath(ply, attacker, dmginfo)
 			attacker:AddFrags(1)
 
 			-- did a hunter kill a prop
-			if attacker:Team() == 2 && ply:Team() == 3 then
+			if attacker:IsHunter() && ply:IsProp() then
 
 				-- increase their round kills
 				attacker.HunterKills = (attacker.HunterKills || 0) + 1
@@ -598,17 +595,17 @@ function GM:PlayerCanHearChatVoice( listener, talker, typ, teamOnly )
 		return true
 	end
 
-	if self:GetGameState() == 3 || self:GetGameState() == 0 then
+	if self:GetGameState() == ROUND_POST || self:GetGameState() == ROUND_WAIT then
 		return true
 	end
 
 	-- spectators and dead players can hear everyone
-	if listener:Team() == 1 || !listener:Alive() then
+	if listener:IsSpectator() || !listener:Alive() then
 		return true
 	end
 
 	-- if the player is dead or a spectator we can't hear them
-	if !talker:Alive() || talker:Team() == 1 then
+	if !talker:Alive() || talker:IsSpectator() then
 		return false
 	end
 
@@ -618,7 +615,7 @@ end
 
 function GM:PlayerCanPickupWeapon(ply, wep)
 	if IsValid(wep) then
-		if ply:Team() == 3 then
+		if ply:IsProp() then
 			return false
 		end
 	end

--- a/gamemodes/husklesph/gamemode/sv_respawn.lua
+++ b/gamemodes/husklesph/gamemode/sv_respawn.lua
@@ -1,11 +1,11 @@
 
 
 function GM:CanRespawn(ply)
-	if ply:Team() == 1 then
+	if ply:IsSpectator() then
 		return false
 	end
 
-	if self:GetGameState() == 0 then
+	if self:GetGameState() == ROUND_WAIT then
 		if ply.NextSpawnTime && ply.NextSpawnTime > CurTime() then return end
 
 		if ply:KeyPressed(IN_JUMP) || ply:KeyPressed(IN_ATTACK) then

--- a/gamemodes/husklesph/gamemode/sv_spectate.lua
+++ b/gamemodes/husklesph/gamemode/sv_spectate.lua
@@ -60,7 +60,7 @@ function GM:SpectateNext(ply, direction)
 	for k, v in pairs(player.GetAll()) do
 		if v != ply then
 			-- can only spectate same team and alive
-			if v:Alive() && (v:Team() == ply:Team() || ply:Team() == 1) then
+			if v:Alive() && (v:Team() == ply:Team() || ply:IsSpectator()) then
 				table.insert(players, v)
 				if v == ply:GetCSpectatee() then
 					index = #players
@@ -79,7 +79,7 @@ function GM:SpectateNext(ply, direction)
 
 		local ent = players[index]
 		if IsValid(ent) then
-			if ent:IsPlayer() && ent:Team() == 2 then
+			if ent:IsPlayer() && ent:IsHunter() then
 				ply:CSpectate(OBS_MODE_IN_EYE, ent)
 			else
 				ply:CSpectate(OBS_MODE_CHASE, ent)
@@ -109,7 +109,7 @@ function GM:ChooseSpectatee(ply)
 	if !ply.SpectateTime || ply.SpectateTime < CurTime() then
 
 		if ply:KeyPressed(IN_JUMP) then
-			if ply:GetCSpectateMode() != OBS_MODE_ROAMING && (ply:Team() == 1 || self.DeadSpectateRoam:GetBool()) then
+			if ply:GetCSpectateMode() != OBS_MODE_ROAMING && (ply:IsSpectator() || self.DeadSpectateRoam:GetBool()) then
 				ply:CSpectate(OBS_MODE_ROAMING)
 			end
 		else

--- a/gamemodes/husklesph/gamemode/sv_taunt.lua
+++ b/gamemodes/husklesph/gamemode/sv_taunt.lua
@@ -103,7 +103,7 @@ cvars.AddChangeCallback("ph_taunt_menu_phrase", function(convar_name, value_old,
 end)
 
 function GM:AutoTauntCheck()
-	if self.GameState ~= 2 then return end
+	if self.GameState ~= ROUND_SEEK then return end
 
 	local propsOnly = self.AutoTauntPropsOnly:GetBool()
 	local minDeadline = self.AutoTauntMin:GetInt()
@@ -111,7 +111,7 @@ function GM:AutoTauntCheck()
 	local badMinMax = minDeadline <= 0 || maxDeadline <= 0 || minDeadline > maxDeadline
 
 	for i, ply in ipairs(player.GetAll()) do
-		if propsOnly && ply:Team() ~= 3 then
+		if propsOnly && !ply:IsProp() then
 			ply.AutoTauntDeadline = nil
 			continue
 		end

--- a/gamemodes/husklesph/gamemode/sv_taunt.lua
+++ b/gamemodes/husklesph/gamemode/sv_taunt.lua
@@ -103,7 +103,7 @@ cvars.AddChangeCallback("ph_taunt_menu_phrase", function(convar_name, value_old,
 end)
 
 function GM:AutoTauntCheck()
-	if self.GameState ~= ROUND_SEEK then return end
+	if self.GameState != ROUND_SEEK then return end
 
 	local propsOnly = self.AutoTauntPropsOnly:GetBool()
 	local minDeadline = self.AutoTauntMin:GetInt()

--- a/gamemodes/husklesph/gamemode/sv_teams.lua
+++ b/gamemodes/husklesph/gamemode/sv_teams.lua
@@ -1,19 +1,19 @@
 
 
 function GM:TeamsSetupPlayer(ply)
-	local cops = team.NumPlayers(2)
-	local robbers = team.NumPlayers(3)
+	local cops = team.NumPlayers(TEAM_HUNTER)
+	local robbers = team.NumPlayers(TEAM_PROP)
 	if robbers <= cops then
-		ply:SetTeam(3)
+		ply:SetTeam(TEAM_PROP)
 	else
-		ply:SetTeam(2)
+		ply:SetTeam(TEAM_HUNTER)
 	end
 end
 
 concommand.Add("car_jointeam", function(ply, com, args)
 	local curteam = ply:Team()
 	local newteam = tonumber(args[1] || "") || 0
-	if newteam == 1 && curteam != 1 then
+	if newteam == TEAM_SPEC && curteam != TEAM_SPEC then
 
 		ply:SetTeam(newteam)
 		if ply:Alive() then
@@ -21,10 +21,10 @@ concommand.Add("car_jointeam", function(ply, com, args)
 		end
 		GlobalChatMsg(ply:Nick(), " changed team to ", team.GetColor(newteam), team.GetName(newteam))
 
-	elseif newteam >= 2 && newteam <= 3 && newteam != curteam then
+	elseif newteam >= TEAM_HUNTER && newteam <= TEAM_PROP && newteam != curteam then
 
 		-- make sure we can't join the bigger team
-		local otherteam = newteam == 2 && 3 || 2
+		local otherteam = newteam == TEAM_HUNTER && TEAM_PROP || TEAM_HUNTER
 		if team.NumPlayers(newteam) <= team.NumPlayers(otherteam) then
 			ply:SetTeam(newteam)
 			if ply:Alive() then
@@ -43,7 +43,7 @@ function GM:CheckTeamBalance()
 	if !self.TeamBalanceCheck || self.TeamBalanceCheck < CurTime() then
 		self.TeamBalanceCheck = CurTime() + 3 * 60 -- check every 3 minutes
 
-		local diff = team.NumPlayers(2) - team.NumPlayers(3)
+		local diff = team.NumPlayers(TEAM_HUNTER) - team.NumPlayers(TEAM_PROP)
 		if diff < -1 || diff > 1 then -- teams must be off by more than 2 for team balance
 			self.TeamBalanceTimer = CurTime() + 30 -- balance in 30 seconds
 			for k,ply in pairs(player.GetAll()) do
@@ -58,12 +58,12 @@ function GM:CheckTeamBalance()
 end
 
 function GM:BalanceTeams(nokill)
-	local diff = team.NumPlayers(2) - team.NumPlayers(3)
+	local diff = team.NumPlayers(TEAM_HUNTER) - team.NumPlayers(TEAM_PROP)
 	if diff < -1 || diff > 1 then -- teams must be off by more than 2 for team balance
-		local biggerTeam, smallerTeam = 3,2
+		local biggerTeam, smallerTeam = TEAM_PROP,TEAM_HUNTER
 		if diff > 0 then
-			biggerTeam = 2
-			smallerTeam = 3
+			biggerTeam = TEAM_HUNTER
+			smallerTeam = TEAM_PROP
 		end
 		diff = team.NumPlayers(biggerTeam) - team.NumPlayers(smallerTeam)
 		while diff > 1 do
@@ -81,10 +81,10 @@ end
 
 function GM:SwapTeams()
 	for k, ply in pairs(player.GetAll()) do
-		if ply:Team() == 2 then
-			ply:SetTeam(3)
-		elseif ply:Team() == 3 then
-			ply:SetTeam(2)
+		if ply:IsHunter() then
+			ply:SetTeam(TEAM_PROP)
+		elseif ply:IsProp() then
+			ply:SetTeam(TEAM_HUNTER)
 		end
 	end
 	GlobalChatMsg(Color(50, 220, 150), "Teams have been swapped")


### PR DESCRIPTION
This PR is the same as #9 except it includes the major refactoring that occurred as a result of 89e70e68ee99a210fe8438b5d1cf59fe7120f29c and c1abe166906b79ccce6104d10ca024cf4670fec3. It was easier to just make a new PR with the changes rather than try to merge in all the refactoring that occurred.

---

This PR adds a bunch of constants and some utility functions. The goal is to try to get rid of the magic numbers present in the codebase. The additions can all be found in gamemode/shared.lua.

For now the added constants have to do with round states, team ids, and win states.
An example usage of the round state constants would be transforming code from this
`if self:GetGameState() == 3 then`
to this
`if self:GetGameState() == ROUND_POST then`

There are also three helper functions added to the Player meta table: IsSpectator, IsHunter, and IsProp. These helpers transform code from this
`if ply:Team() == 2 then`
into this
`if ply:IsHunter() then`

I am starting this PR as a draft because I consider this a work in progress as I try to identify what else would be good to add. Any feedback or ideas for additions are appreciated.