### PR TITLE
Player awards rework

### DIFF
--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -449,7 +449,7 @@ function GM:EndRoundMenuResults(res)
 			-- surface.DrawOutlinedRect(0, 0, w, h)
 			draw.DrawText(award.name, "RobotoHUD-20", 0, 0, Color(220, 220, 220), 0)
 			draw.DrawText(award.desc, "RobotoHUD-15", 0, draw.GetFontHeight("RobotoHUD-20"), Color(120, 120, 120), 0)
-			draw.DrawText(award.winner:Nick(), "RobotoHUD-25", w, h / 2 - draw.GetFontHeight("RobotoHUD-25") / 2, team.GetColor(award.winner:Team()), 2)
+			draw.DrawText(award.winnerName, "RobotoHUD-25", w, h / 2 - draw.GetFontHeight("RobotoHUD-25") / 2, team.GetColor(award.winnerTeam), 2)
 		end
 
 		menu.ResultList:AddItem(pnl)

--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -424,36 +424,6 @@ function GM:CloseEndRoundMenu()
 	end
 end
 
-local awards = {
-	LastPropStanding = {
-		name = "Longest Survivor",
-		desc = "Prop who survived longest"
-	},
-	LeastMovement = {
-		name = "Least Movement",
-		desc = "Prop who moved the least"
-	},
-	MostTaunts = {
-		name = "Most Taunts",
-		desc = "Prop who taunted the most"
-	},
-	FirstHunterKill = {
-		name = "First Blood",
-		desc = "Hunter who had the first kill"
-	},
-	MostKills = {
-		name = "Most Kills",
-		desc = "Hunter who had the most kills"
-	},
-	PropDamage = {
-		name = "Angriest Player",
-		desc = "Hunter who shot at props the most"
-	},
-	MostMovement = {
-		name = "Most Movement",
-		desc = "Prop who moved the most"
-	}
-}
 
 function GM:EndRoundMenuResults(res)
 	self:OpenEndRoundMenu()
@@ -471,28 +441,18 @@ function GM:EndRoundMenuResults(res)
 		menu.WinningTeam:SetColor(Color(150, 150, 150))
 	end
 
-	--randomise award order, preserve keys
-	local random = {}
-	for k, award in pairs(awards) do
-		table.insert(random, math.random(#random) + 1, {k, award})
-	end
-
-	for _, v in pairs(random) do
-		local k, award = v[1], v[2]
-		if res.playerAwards[k] then
-			local t = res.playerAwards[k]
-			local pnl = vgui.Create("DPanel")
-			pnl:SetTall(math.max(draw.GetFontHeight("RobotoHUD-35"), draw.GetFontHeight("RobotoHUD-15") + draw.GetFontHeight("RobotoHUD-20") * 1.1))
-			function pnl:Paint(w, h)
-				surface.SetDrawColor(50, 50, 50)
-				-- surface.DrawOutlinedRect(0, 0, w, h)
-				draw.DrawText(award.name, "RobotoHUD-20", 0, 0, Color(220, 220, 220), 0)
-				draw.DrawText(award.desc, "RobotoHUD-15", 0, draw.GetFontHeight("RobotoHUD-20"), Color(120, 120, 120), 0)
-				draw.DrawText(t.name, "RobotoHUD-25", w, h / 2 - draw.GetFontHeight("RobotoHUD-25") / 2, t.color, 2)
-			end
-
-			menu.ResultList:AddItem(pnl)
+	for _, award in pairs(res.playerAwards) do
+		local pnl = vgui.Create("DPanel")
+		pnl:SetTall(math.max(draw.GetFontHeight("RobotoHUD-35"), draw.GetFontHeight("RobotoHUD-15") + draw.GetFontHeight("RobotoHUD-20") * 1.1))
+		function pnl:Paint(w, h)
+			surface.SetDrawColor(50, 50, 50)
+			-- surface.DrawOutlinedRect(0, 0, w, h)
+			draw.DrawText(award.name, "RobotoHUD-20", 0, 0, Color(220, 220, 220), 0)
+			draw.DrawText(award.desc, "RobotoHUD-15", 0, draw.GetFontHeight("RobotoHUD-20"), Color(120, 120, 120), 0)
+			draw.DrawText(award.winner:Nick(), "RobotoHUD-25", w, h / 2 - draw.GetFontHeight("RobotoHUD-25") / 2, team.GetColor(award.winner:Team()), 2)
 		end
+
+		menu.ResultList:AddItem(pnl)
 	end
 end
 

--- a/gamemodes/husklesph/gamemode/cl_rounds.lua
+++ b/gamemodes/husklesph/gamemode/cl_rounds.lua
@@ -34,20 +34,7 @@ net.Receive("round_victor", function(len)
 		tab.winningTeam = net.ReadUInt(16)
 	end
 
-	-- TODO: Can this be sent by the server, rather than being reconstructed?
-	tab.playerAwards = {}
-	while net.ReadUInt(8) != 0 do
-		local k = net.ReadString()
-		local v = net.ReadEntity()
-		net.ReadVector() -- TODO: Remove this on both sides.
-		local name = net.ReadString()
-
-		tab.playerAwards[k] = {
-			player = v,
-			name = name,
-			color = team.GetColor(v:Team())
-		}
-	end
+	tab.playerAwards = net.ReadTable()
 
 	-- open the results panel
 	timer.Simple(2, function()

--- a/gamemodes/husklesph/gamemode/sv_awards.lua
+++ b/gamemodes/husklesph/gamemode/sv_awards.lua
@@ -1,137 +1,122 @@
--- last prop death award
-local function lastPropStandingCalcuation()
-	if GAMEMODE.LastRoundResult == WIN_HUNTER then
-		return GAMEMODE.LastPropDeath
-	end
-
-	return nil
-end
+PlayerAwards = {}
 
 
--- get prop with least movement
-local function leastMovementCalcuation()
-	local minPly
-
-	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if !ply:IsProp() then continue end
-
-		if !minPly || ply.PropMovement < minPly.PropMovement then
-			minPly = ply
+PlayerAwards.LastPropStanding = {
+	name = "Longest Survivor",
+	desc = "Prop who survived longest",
+	getWinner = function()
+		if GAMEMODE.LastRoundResult == WIN_HUNTER then
+			return GAMEMODE.LastPropDeath
 		end
+
+		return nil
 	end
-
-	return minPly
-end
+}
 
 
--- get prop with most taunts
-local function mostTauntsCalcuation()
-	local maxPly
+PlayerAwards.LeastMovement = {
+	name = "Least Movement",
+	desc = "Prop who moved the least",
+	getWinner = function()
+		local minPly
 
-	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if !ply:IsProp() then continue end
+		for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+			if !ply:IsProp() then continue end
 
-		if !maxPly || ply.TauntAmount > maxPly.TauntAmount then
-			maxPly = ply
+			if !minPly || ply.PropMovement < minPly.PropMovement then
+				minPly = ply
+			end
 		end
+
+		return minPly
 	end
-
-	if maxPly && maxPly.TauntAmount > 0 then return maxPly end
-	return nil
-end
+}
 
 
--- first hunter kill award
-local function firstHunterKillCalcuation()
-	return GAMEMODE.FirstHunterKill
-end
+PlayerAwards.MostTaunts = {
+	name = "Most Taunts",
+	desc = "Prop who taunted the most",
+	getWinner = function()
+		local maxPly
 
+		for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+			if !ply:IsProp() then continue end
 
--- get hunter with most kills
-local function mostKillsCalcuation()
-	local maxPly
-
-	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if !ply:IsHunter() then continue end
-
-		if !killsPly || ply.HunterKills > maxPly.HunterKills then
-			maxPly = ply
+			if !maxPly || ply.TauntAmount > maxPly.TauntAmount then
+				maxPly = ply
+			end
 		end
+
+		if maxPly && maxPly.TauntAmount > 0 then return maxPly end
+		return nil
 	end
-
-	if maxPly && maxPly.HunterKills > 0 then return maxPly end
-	return nil
-end
+}
 
 
--- get hunter with most prop damage
-local function propDamageCalcuation()
-	local maxPly
+PlayerAwards.FirstHunterKill = {
+	name = "First Blood",
+	desc = "Hunter who had the first kill",
+	getWinner = function()
+		return GAMEMODE.FirstHunterKill
+	end
+}
 
-	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if !ply:IsHunter() then continue end
 
-		if !maxPly || ply.PropDmgPenalty > maxPly.PropDmgPenalty then
-			maxPly = ply
+PlayerAwards.MostKills = {
+	name = "Most Kills",
+	desc = "Hunter who had the most kills",
+	getWinner = function()
+		local maxPly
+
+		for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+			if !ply:IsHunter() then continue end
+
+			if !killsPly || ply.HunterKills > maxPly.HunterKills then
+				maxPly = ply
+			end
 		end
+
+		if maxPly && maxPly.HunterKills > 0 then return maxPly end
+		return nil
 	end
-
-	if maxPly && maxPly.PropDmgPenalty > 0 then return maxPly end
-	return nil
-end
+}
 
 
--- get prop with most movement
-local function mostMovementCalcuation()
-	local maxPly
+PlayerAwards.PropDamage = {
+	name = "Angriest Player",
+	desc = "Hunter who shot at props the most",
+	getWinner = function()
+		local maxPly
 
-	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if !ply:IsProp() then continue end
+		for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+			if !ply:IsHunter() then continue end
 
-		if !maxPly || ply.PropMovement > maxPly.PropMovement then
-			maxPly = ply
+			if !maxPly || ply.PropDmgPenalty > maxPly.PropDmgPenalty then
+				maxPly = ply
+			end
 		end
+
+		if maxPly && maxPly.PropDmgPenalty > 0 then return maxPly end
+		return nil
 	end
-
-	if maxPly && maxPly.PropMovement > 0 then return maxPly end
-	return nil
-end
+}
 
 
-PlayerAwardsTemplate = {
-	LastPropStanding = {
-		name = "Longest Survivor",
-		desc = "Prop who survived longest",
-		getWinner = lastPropStandingCalcuation
-	},
-	LeastMovement = {
-		name = "Least Movement",
-		desc = "Prop who moved the least",
-		getWinner = leastMovementCalcuation
-	},
-	MostTaunts = {
-		name = "Most Taunts",
-		desc = "Prop who taunted the most",
-		getWinner = mostTauntsCalcuation
-	},
-	FirstHunterKill = {
-		name = "First Blood",
-		desc = "Hunter who had the first kill",
-		getWinner = firstHunterKillCalcuation
-	},
-	MostKills = {
-		name = "Most Kills",
-		desc = "Hunter who had the most kills",
-		getWinner = mostKillsCalcuation
-	},
-	PropDamage = {
-		name = "Angriest Player",
-		desc = "Hunter who shot at props the most",
-		getWinner = propDamageCalcuation
-	},
-	MostMovement = {
-		name = "Most Movement",
-		desc = "Prop who moved the most",
-		getWinner = mostMovementCalcuation
-	}
+PlayerAwards.MostMovement = {
+	name = "Most Movement",
+	desc = "Prop who moved the most",
+	getWinner = function()
+		local maxPly
+
+		for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+			if !ply:IsProp() then continue end
+
+			if !maxPly || ply.PropMovement > maxPly.PropMovement then
+				maxPly = ply
+			end
+		end
+
+		if maxPly && maxPly.PropMovement > 0 then return maxPly end
+		return nil
+	end
 }

--- a/gamemodes/husklesph/gamemode/sv_awards.lua
+++ b/gamemodes/husklesph/gamemode/sv_awards.lua
@@ -36,7 +36,8 @@ local function mostTauntsCalcuation()
 		end
 	end
 
-	return (maxPly && maxPly.TauntAmount > 0) && maxPly || nil
+	if maxPly && maxPly.TauntAmount > 0 then return maxPly end
+	return nil
 end
 
 
@@ -58,7 +59,8 @@ local function mostKillsCalcuation()
 		end
 	end
 
-	return (maxPly && maxPly.HunterKills > 0) && maxPly || nil
+	if maxPly && maxPly.HunterKills > 0 then return maxPly end
+	return nil
 end
 
 
@@ -74,7 +76,8 @@ local function propDamageCalcuation()
 		end
 	end
 
-	return (maxPly && maxPly.PropDmgPenalty > 0) && maxPly || nil
+	if maxPly && maxPly.PropDmgPenalty > 0 then return maxPly end
+	return nil
 end
 
 
@@ -90,7 +93,8 @@ local function mostMovementCalcuation()
 		end
 	end
 
-	return (maxPly && maxPly.PropMovement > 0) && maxPly || nil
+	if maxPly && maxPly.PropMovement > 0 then return maxPly end
+	return nil
 end
 
 

--- a/gamemodes/husklesph/gamemode/sv_awards.lua
+++ b/gamemodes/husklesph/gamemode/sv_awards.lua
@@ -1,6 +1,6 @@
 -- last prop death award
 local function lastPropStandingCalcuation()
-	if GAMEMODE.LastRoundResult == 2 then
+	if GAMEMODE.LastRoundResult == WIN_HUNTER then
 		return GAMEMODE.LastPropDeath
 	end
 
@@ -13,7 +13,7 @@ local function leastMovementCalcuation()
 	local minPly
 
 	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if ply:Team() != 3 then continue end
+		if !ply:IsProp() then continue end
 
 		if !minPly || ply.PropMovement < minPly.PropMovement then
 			minPly = ply
@@ -29,7 +29,7 @@ local function mostTauntsCalcuation()
 	local maxPly
 
 	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if ply:Team() != 3 then continue end
+		if !ply:IsProp() then continue end
 
 		if !maxPly || ply.TauntAmount > maxPly.TauntAmount then
 			maxPly = ply
@@ -52,7 +52,7 @@ local function mostKillsCalcuation()
 	local maxPly
 
 	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if ply:Team() != 2 then continue end
+		if !ply:IsHunter() then continue end
 
 		if !killsPly || ply.HunterKills > maxPly.HunterKills then
 			maxPly = ply
@@ -69,7 +69,7 @@ local function propDamageCalcuation()
 	local maxPly
 
 	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if ply:Team() != 2 then continue end
+		if !ply:IsHunter() then continue end
 
 		if !maxPly || ply.PropDmgPenalty > maxPly.PropDmgPenalty then
 			maxPly = ply
@@ -86,7 +86,7 @@ local function mostMovementCalcuation()
 	local maxPly
 
 	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
-		if ply:Team() != 3 then continue end
+		if !ply:IsProp() then continue end
 
 		if !maxPly || ply.PropMovement > maxPly.PropMovement then
 			maxPly = ply

--- a/gamemodes/husklesph/gamemode/sv_awards.lua
+++ b/gamemodes/husklesph/gamemode/sv_awards.lua
@@ -1,0 +1,133 @@
+-- last prop death award
+local function lastPropStandingCalcuation()
+	if GAMEMODE.LastRoundResult == 2 then
+		return GAMEMODE.LastPropDeath
+	end
+
+	return nil
+end
+
+
+-- get prop with least movement
+local function leastMovementCalcuation()
+	local minPly
+
+	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+		if ply:Team() != 3 then continue end
+
+		if !minPly || ply.PropMovement < minPly.PropMovement then
+			minPly = ply
+		end
+	end
+
+	return minPly
+end
+
+
+-- get prop with most taunts
+local function mostTauntsCalcuation()
+	local maxPly
+
+	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+		if ply:Team() != 3 then continue end
+
+		if !maxPly || ply.TauntAmount > maxPly.TauntAmount then
+			maxPly = ply
+		end
+	end
+
+	return (maxPly && maxPly.TauntAmount > 0) && maxPly || nil
+end
+
+
+-- first hunter kill award
+local function firstHunterKillCalcuation()
+	return GAMEMODE.FirstHunterKill
+end
+
+
+-- get hunter with most kills
+local function mostKillsCalcuation()
+	local maxPly
+
+	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+		if ply:Team() != 2 then continue end
+
+		if !killsPly || ply.HunterKills > maxPly.HunterKills then
+			maxPly = ply
+		end
+	end
+
+	return (maxPly && maxPly.HunterKills > 0) && maxPly || nil
+end
+
+
+-- get hunter with most prop damage
+local function propDamageCalcuation()
+	local maxPly
+
+	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+		if ply:Team() != 2 then continue end
+
+		if !maxPly || ply.PropDmgPenalty > maxPly.PropDmgPenalty then
+			maxPly = ply
+		end
+	end
+
+	return (maxPly && maxPly.PropDmgPenalty > 0) && maxPly || nil
+end
+
+
+-- get prop with most movement
+local function mostMovementCalcuation()
+	local maxPly
+
+	for _, ply in ipairs(GAMEMODE:GetPlayingPlayers()) do
+		if ply:Team() != 3 then continue end
+
+		if !maxPly || ply.PropMovement > maxPly.PropMovement then
+			maxPly = ply
+		end
+	end
+
+	return (maxPly && maxPly.PropMovement > 0) && maxPly || nil
+end
+
+
+PlayerAwardsTemplate = {
+	LastPropStanding = {
+		name = "Longest Survivor",
+		desc = "Prop who survived longest",
+		getWinner = lastPropStandingCalcuation
+	},
+	LeastMovement = {
+		name = "Least Movement",
+		desc = "Prop who moved the least",
+		getWinner = leastMovementCalcuation
+	},
+	MostTaunts = {
+		name = "Most Taunts",
+		desc = "Prop who taunted the most",
+		getWinner = mostTauntsCalcuation
+	},
+	FirstHunterKill = {
+		name = "First Blood",
+		desc = "Hunter who had the first kill",
+		getWinner = firstHunterKillCalcuation
+	},
+	MostKills = {
+		name = "Most Kills",
+		desc = "Hunter who had the most kills",
+		getWinner = mostKillsCalcuation
+	},
+	PropDamage = {
+		name = "Angriest Player",
+		desc = "Hunter who shot at props the most",
+		getWinner = propDamageCalcuation
+	},
+	MostMovement = {
+		name = "Most Movement",
+		desc = "Prop who moved the most",
+		getWinner = mostMovementCalcuation
+	}
+}

--- a/gamemodes/husklesph/gamemode/sv_rounds.lua
+++ b/gamemodes/husklesph/gamemode/sv_rounds.lua
@@ -204,16 +204,17 @@ function GM:EndRound(reason)
 	end
 	self.LastRoundResult = reason
 
-	self.PlayerAwards = {}
-	for awardKey, award in pairs(PlayerAwardsTemplate) do
+	local PlayerAwardsResults = {}
+	for awardKey, award in pairs(PlayerAwards) do -- PlayerAwards comes from sv_awards.lua
 		local result = award.getWinner()
 
-		-- nil values cannot exist in self.PlayerAwards otherwise the net.WriteTable below will break
+		-- nil values cannot exist in PlayerAwardsResults otherwise the net.WriteTable below will break
 		if type(result) == "Player" then
-			self.PlayerAwards[awardKey] = {
+			PlayerAwardsResults[awardKey] = {
 				name = award.name,
 				desc = award.desc,
-				winner = result
+				winnerName = result:Nick(),
+				winnerTeam = result:Team()
 			}
 		end
 	end
@@ -223,7 +224,7 @@ function GM:EndRound(reason)
 	if winningTeam then
 		net.WriteUInt(winningTeam, 16)
 	end
-	net.WriteTable(self.PlayerAwards)
+	net.WriteTable(PlayerAwardsResults)
 	net.Broadcast()
 
 	self.RoundSettings.NextRoundTime = 15

--- a/gamemodes/husklesph/gamemode/sv_rounds.lua
+++ b/gamemodes/husklesph/gamemode/sv_rounds.lua
@@ -1,3 +1,5 @@
+include("sv_awards.lua")
+
 util.AddNetworkString("gamestate")
 util.AddNetworkString("round_victor")
 util.AddNetworkString("gamerules")
@@ -210,83 +212,17 @@ function GM:EndRound(reason)
 	self.LastRoundResult = reason
 
 	self.PlayerAwards = {}
+	for awardKey, award in pairs(PlayerAwardsTemplate) do
+		local result = award.getWinner()
 
-	local propPly, propDmg = nil, 0
-	local killsPly, killsAmo = nil, 0
-	local leastMovePly, leastMoveAmo
-	local mostMovePly, mostMoveAmo
-	local tauntsPly, tauntsAmo = nil, 0
-	for k, ply in pairs(self:GetPlayingPlayers()) do
-
-		-- TODO replace with better statistic tracker
-		ply.HunterKills = ply.HunterKills || 0
-		ply.PropDmgPenalty = ply.PropDmgPenalty || 0
-		ply.TauntAmount = ply.TauntAmount || 0
-		ply.PropMovement = ply.PropMovement || 0
-
-		if ply:Team() == 2 then -- hunters
-
-			-- get hunter with most prop damage
-			if ply.PropDmgPenalty > propDmg then
-				propDmg = ply.PropDmgPenalty
-				propPly = ply
-			end
-
-			-- get hunter with most kills
-			if ply.HunterKills > killsAmo then
-				killsAmo = ply.PropDmgPenalty
-				killsPly = ply
-			end
-		else
-
-			-- get prop with least movement
-			if leastMoveAmo == nil || ply.PropMovement < leastMoveAmo then
-				leastMoveAmo = ply.PropMovement
-				leastMovePly = ply
-			end
-
-			-- get prop with most movement
-			if mostMoveAmo == nil || ply.PropMovement > mostMoveAmo then
-				mostMoveAmo = ply.PropMovement
-				mostMovePly = ply
-			end
-
-			-- get prop with most taunts
-			if ply.TauntAmount > tauntsAmo then
-				tauntsAmo = ply.TauntAmount
-				tauntsPly = ply
-			end
+		-- nil values cannot exist in self.PlayerAwards otherwise the net.WriteTable below will break
+		if type(result) == "Player" then
+			self.PlayerAwards[awardKey] = {
+				name = award.name,
+				desc = award.desc,
+				winner = result
+			}
 		end
-	end
-
-	if propPly then
-		self.PlayerAwards["PropDamage"] = propPly
-	end
-
-	if leastMovePly then
-		self.PlayerAwards["LeastMovement"] = leastMovePly
-	end
-
-	if mostMovePly then
-		self.PlayerAwards["MostMovement"] = mostMovePly
-	end
-
-	if killsPly then
-		self.PlayerAwards["MostKills"] = killsPly
-	end
-
-	if tauntsPly then
-		self.PlayerAwards["MostTaunts"] = tauntsPly
-	end
-
-	-- last prop death award
-	if IsValid(self.LastPropDeath) && reason == 2 then
-		self.PlayerAwards["LastPropStanding"] = self.LastPropDeath
-	end
-
-	-- first hunter kill award
-	if IsValid(self.FirstHunterKill) then
-		self.PlayerAwards["FirstHunterKill"] = self.FirstHunterKill
 	end
 
 	net.Start("round_victor")
@@ -294,14 +230,7 @@ function GM:EndRound(reason)
 	if winningTeam then
 		net.WriteUInt(winningTeam, 16)
 	end
-	for k, v in pairs(self.PlayerAwards) do
-		net.WriteUInt(1, 8)
-		net.WriteString(tostring(k))
-		net.WriteEntity(v)
-		net.WriteVector(v:GetPlayerColor())
-		net.WriteString(v:Nick())
-	end
-	net.WriteUInt(0, 8)
+	net.WriteTable(self.PlayerAwards)
 	net.Broadcast()
 
 	self.RoundSettings.NextRoundTime = 15

--- a/gamemodes/husklesph/gamemode/sv_rounds.lua
+++ b/gamemodes/husklesph/gamemode/sv_rounds.lua
@@ -209,13 +209,17 @@ function GM:EndRound(reason)
 		local result = award.getWinner()
 
 		-- nil values cannot exist in awards otherwise the net.WriteTable below will break
-		if type(result) == "Player" then
+		if !result then
+			continue
+		elseif type(result) == "Player" then
 			awards[awardKey] = {
 				name = award.name,
 				desc = award.desc,
 				winnerName = result:Nick(),
 				winnerTeam = result:Team()
 			}
+		else
+			ErrorNoHalt("PROPHUNTERS WARNING: EndRound Player Award gave non Player object: " .. type(result))
 		end
 	end
 

--- a/gamemodes/husklesph/gamemode/sv_rounds.lua
+++ b/gamemodes/husklesph/gamemode/sv_rounds.lua
@@ -134,6 +134,10 @@ function GM:SetupRound()
 				ply:Freeze(true)
 			end
 
+			ply.PropDmgPenalty = 0
+			ply.PropMovement = 0
+			ply.HunterKills = 0
+			ply.TauntAmount = 0
 			ply.TauntsUsed = {}
 			ply.TauntEnd = nil
 			ply.AutoTauntDeadline = nil

--- a/gamemodes/husklesph/gamemode/sv_rounds.lua
+++ b/gamemodes/husklesph/gamemode/sv_rounds.lua
@@ -204,13 +204,13 @@ function GM:EndRound(reason)
 	end
 	self.LastRoundResult = reason
 
-	local PlayerAwardsResults = {}
+	local awards = {}
 	for awardKey, award in pairs(PlayerAwards) do -- PlayerAwards comes from sv_awards.lua
 		local result = award.getWinner()
 
-		-- nil values cannot exist in PlayerAwardsResults otherwise the net.WriteTable below will break
+		-- nil values cannot exist in awards otherwise the net.WriteTable below will break
 		if type(result) == "Player" then
-			PlayerAwardsResults[awardKey] = {
+			awards[awardKey] = {
 				name = award.name,
 				desc = award.desc,
 				winnerName = result:Nick(),
@@ -224,7 +224,7 @@ function GM:EndRound(reason)
 	if winningTeam then
 		net.WriteUInt(winningTeam, 16)
 	end
-	net.WriteTable(PlayerAwardsResults)
+	net.WriteTable(awards)
 	net.Broadcast()
 
 	self.RoundSettings.NextRoundTime = 15


### PR DESCRIPTION
This reworks the player awards system to be less fractured over a few files and instead moves everything to a single, new file. The new file `sv_awards.lua` contains all of the code for specifying awards and calculating their winners. Existing code has been modified to suit this new format.

Several awards have been tweaked so that they don't give a winner if the determined "winner" doesn't actually have any progress towards that award. For example, if the winner of the "Most Taunts" award actually taunted 0 times then we won't give a winner.