### PR TITLE
Style fixes

### DIFF
--- a/gamemodes/husklesph/entities/effects/ph_disguise/init.lua
+++ b/gamemodes/husklesph/entities/effects/ph_disguise/init.lua
@@ -11,8 +11,6 @@ function EFFECT:Init( data )
 	self.Emitter = ParticleEmitter( self.pos )
 
 	for i = 1, 17 do
-
-		-- local particle = self.Emitter:Add( "particle/particle_smokegrenade1", self.pos + VectorRand() * self.Scale / 2)
 		local t = Vector(math.Rand(-self.Scale, self.Scale), math.Rand(-self.Scale, self.Scale), math.Rand(0, self.Mag))
 		local particle = self.Emitter:Add( "particle/smokesprites_000" .. math.random(1, 9), self.pos + t)
 		particle:SetVelocity( t:GetNormal() )
@@ -22,7 +20,6 @@ function EFFECT:Init( data )
 		particle:SetStartSize( self.Scale * 2 )
 		particle:SetEndSize( self.Scale * 2 )
 		particle:SetRoll( math.random(0,360) )
-		--particle:SetRollDelta( 0 )
 		local x = math.random(50, 150)
 		particle:SetColor( x, x, x )
 
@@ -33,10 +30,8 @@ function EFFECT:Init( data )
 end
 
 function EFFECT:Think( )
-	-- if self.StartTime + 0.5 < CurTime() then
-		self.Emitter:Finish()
-		return false
-	-- end
+	self.Emitter:Finish()
+	return false
 end
 
 function EFFECT:Render()

--- a/gamemodes/husklesph/entities/effects/ph_disguise/init.lua
+++ b/gamemodes/husklesph/entities/effects/ph_disguise/init.lua
@@ -17,7 +17,7 @@ function EFFECT:Init(data)
 		particle:SetEndAlpha(0)
 		particle:SetStartSize(self.Scale * 2)
 		particle:SetEndSize(self.Scale * 2)
-		particle:SetRoll(math.random(0,360))
+		particle:SetRoll(math.random(0, 360))
 		local x = math.random(50, 150)
 		particle:SetColor(x, x, x)
 	end

--- a/gamemodes/husklesph/entities/effects/ph_disguise/init.lua
+++ b/gamemodes/husklesph/entities/effects/ph_disguise/init.lua
@@ -1,6 +1,4 @@
-
-function EFFECT:Init( data )
-
+function EFFECT:Init(data)
 	self.StartTime = CurTime()
 	self.NextFlame = CurTime()
 
@@ -8,28 +6,24 @@ function EFFECT:Init( data )
 	self.Scale = data:GetScale()
 	self.Mag = data:GetMagnitude()
 
-	self.Emitter = ParticleEmitter( self.pos )
+	self.Emitter = ParticleEmitter(self.pos)
 
 	for i = 1, 17 do
 		local t = Vector(math.Rand(-self.Scale, self.Scale), math.Rand(-self.Scale, self.Scale), math.Rand(0, self.Mag))
-		local particle = self.Emitter:Add( "particle/smokesprites_000" .. math.random(1, 9), self.pos + t)
-		particle:SetVelocity( t:GetNormal() )
-		particle:SetDieTime( 5.2)
-		particle:SetStartAlpha( 20 )
-		particle:SetEndAlpha( 0 )
-		particle:SetStartSize( self.Scale * 2 )
-		particle:SetEndSize( self.Scale * 2 )
-		particle:SetRoll( math.random(0,360) )
+		local particle = self.Emitter:Add("particle/smokesprites_000" .. math.random(1, 9), self.pos + t)
+		particle:SetVelocity(t:GetNormal())
+		particle:SetDieTime(5.2)
+		particle:SetStartAlpha(20)
+		particle:SetEndAlpha(0)
+		particle:SetStartSize(self.Scale * 2)
+		particle:SetEndSize(self.Scale * 2)
+		particle:SetRoll(math.random(0,360))
 		local x = math.random(50, 150)
-		particle:SetColor( x, x, x )
-
+		particle:SetColor(x, x, x)
 	end
-
-
-
 end
 
-function EFFECT:Think( )
+function EFFECT:Think()
 	self.Emitter:Finish()
 	return false
 end

--- a/gamemodes/husklesph/entities/entities/ph_disguise.lua
+++ b/gamemodes/husklesph/entities/entities/ph_disguise.lua
@@ -22,7 +22,7 @@ function ENT:Initialize()
 	end
 end
 
-if (CLIENT) then
+if CLIENT then
 	function ENT:Draw()
 		self:DrawModel()
 	end

--- a/gamemodes/husklesph/entities/entities/ph_disguise.lua
+++ b/gamemodes/husklesph/entities/entities/ph_disguise.lua
@@ -1,48 +1,40 @@
-
 AddCSLuaFile()
 
-DEFINE_BASECLASS( "base_anim" )
+DEFINE_BASECLASS("base_anim")
 
-ENT.PrintName		= "Disguise Ent"
-ENT.Author			= "Mechanical Mind"
-ENT.Information		= ""
-ENT.Category		= ""
+ENT.PrintName = "Disguise Ent"
+ENT.Author = "Mechanical Mind"
+ENT.Information = ""
+ENT.Category = ""
 
-ENT.Editable			= true
-ENT.Spawnable			= true
-ENT.AdminOnly			= false
-ENT.RenderGroup 		= RENDERGROUP_BOTH
+ENT.Editable = true
+ENT.Spawnable = true
+ENT.AdminOnly = false
+ENT.RenderGroup = RENDERGROUP_BOTH
 
 function ENT:SetupDataTables()
-
 end
-
 
 function ENT:Initialize()
-
 	if SERVER then
-		self:SetMoveType( MOVETYPE_NONE )
-		self:SetSolid( SOLID_NONE )
+		self:SetMoveType(MOVETYPE_NONE)
+		self:SetSolid(SOLID_NONE)
 	end
-
 end
 
-if ( CLIENT ) then
-
+if (CLIENT) then
 	function ENT:Draw()
 		self:DrawModel()
 	end
-
 end
 
-function ENT:PhysicsCollide( data, physobj )
-
+function ENT:PhysicsCollide(data, physobj)
 end
 
-function ENT:OnTakeDamage( dmginfo )
+function ENT:OnTakeDamage(dmginfo)
 end
 
-function ENT:Use( ply, caller )
+function ENT:Use(ply, caller)
 end
 
 function ENT:Think()

--- a/gamemodes/husklesph/gamemode/cl_bannedmodels.lua
+++ b/gamemodes/husklesph/gamemode/cl_bannedmodels.lua
@@ -2,15 +2,12 @@
 -- menu. It is used locally to determine if a model is viable (aka
 -- whether or not it gets an outline when moused over).
 
-
 GM.BannedModels = {} -- This is used as a hash table where the key is the model string and the value is true.
 local menu
-
 
 function GM:IsModelBanned(model)
 	return self.BannedModels[model] == true
 end
-
 
 function GM:AddBannedModel(model)
 	if self.BannedModels[model] == true then return end
@@ -19,14 +16,12 @@ function GM:AddBannedModel(model)
 	menu.AddModel(model)
 end
 
-
 function GM:RemoveBannedModel(model)
 	if self.BannedModels[model] != true then return end
 
 	self.BannedModels[model] = nil
 	menu.RemoveModel(model)
 end
-
 
 net.Receive("ph_bannedmodels_getall", function(len)
 	GAMEMODE.BannedModels = {}
@@ -38,23 +33,19 @@ net.Receive("ph_bannedmodels_getall", function(len)
 	end
 end)
 
-
 net.Receive("ph_bannedmodels_add", function(len)
 	local model = net.ReadString()
 	GAMEMODE:AddBannedModel(model)
 end)
-
 
 net.Receive("ph_bannedmodels_remove", function(len)
 	local model = net.ReadString()
 	GAMEMODE:RemoveBannedModel(model)
 end)
 
-
 concommand.Add("ph_bannedmodels_menu", function(client)
 	menu:SetVisible(true)
 end)
-
 
 -- This is all the code to create the banned models menu.
 function GM:CreateBannedModelsMenu()

--- a/gamemodes/husklesph/gamemode/cl_chatmsg.lua
+++ b/gamemodes/husklesph/gamemode/cl_chatmsg.lua
@@ -4,7 +4,6 @@
 -- can't do) and we want to be able to send messages from the server (MsgC can't do
 -- this).
 
-
 net.Receive("ph_chatmsg", function(len)
 	local tbl = net.ReadTable()
 	chat.AddText(unpack(tbl))

--- a/gamemodes/husklesph/gamemode/cl_disguise.lua
+++ b/gamemodes/husklesph/gamemode/cl_disguise.lua
@@ -14,7 +14,6 @@ local function renderDis(self)
 
 				local ent = ply:GetNWEntity("disguiseEntity")
 				if IsValid(ent) then
-					-- ent:SetNoDraw(false)
 					local mins = ply:GetNWVector("disguiseMins")
 					local maxs = ply:GetNWVector("disguiseMaxs")
 					local ang = ply:EyeAngles()
@@ -29,10 +28,7 @@ local function renderDis(self)
 					center:Rotate(ang)
 					ent:SetPos(pos - center)
 					ent:SetAngles(ang)
-					-- ent:SetupBones()
 					ent:SetSkin(ply:GetNWInt("disguiseSkin", 1))
-					-- ent:DrawShadow()
-					-- ent:DrawModel()
 				end
 			end
 		end

--- a/gamemodes/husklesph/gamemode/cl_disguise.lua
+++ b/gamemodes/husklesph/gamemode/cl_disguise.lua
@@ -11,7 +11,6 @@ local function renderDis(self)
 		if ply:Alive() && ply:IsDisguised() then
 			local model = ply:GetNWString("disguiseModel")
 			if model && model != "" then
-
 				local ent = ply:GetNWEntity("disguiseEntity")
 				if IsValid(ent) then
 					local mins = ply:GetNWVector("disguiseMins")
@@ -36,8 +35,7 @@ local function renderDis(self)
 end
 
 function GM:RenderDisguises()
-
-	cam.Start3D( EyePos(), EyeAngles() )
+	cam.Start3D(EyePos(), EyeAngles())
 	local b, err = pcall(renderDis, self)
 	cam.End3D()
 	if !b then

--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -3,12 +3,10 @@ if GAMEMODE && IsValid(GAMEMODE.EndRoundPanel) then
 end
 
 local menu
-
 local muted = Material("icon32/muted.png")
 local unmuted = Material("icon32/unmuted.png")
 
 local function addPlayerItem(self, mlist, ply)
-
 	local but = vgui.Create("DButton")
 	but.player = ply
 	but.ctime = CurTime()
@@ -16,7 +14,6 @@ local function addPlayerItem(self, mlist, ply)
 	but:SetText("")
 
 	function but:Paint(w, h)
-
 		surface.SetDrawColor(color_black)
 
 		if IsValid(ply) && ply:IsPlayer() then
@@ -25,13 +22,12 @@ local function addPlayerItem(self, mlist, ply)
 				surface.SetDrawColor(col.r, col.g, col.b, 20)
 				surface.DrawRect(0, 0, w, h)
 			end
-			local s = 4
 
+			local s = 4
 			if ply:IsSpeaking() then
 				surface.SetMaterial(unmuted)
 
 				local v = ply:VoiceVolume()
-
 				local x, y = self:LocalToScreen(0, 0)
 				render.SetScissorRect(x, y, x + s + 32 * (0.5 + v / 2), y + h, true)
 
@@ -53,7 +49,6 @@ local function addPlayerItem(self, mlist, ply)
 			end
 
 			draw.SimpleText(ply:Ping(), "RobotoHUD-20", w - 4, 0, col, 2)
-
 			draw.SimpleText(ply:Nick(), "RobotoHUD-20", s, 0, col, 0)
 		end
 	end
@@ -68,11 +63,9 @@ local function addPlayerItem(self, mlist, ply)
 end
 
 local function doPlayerItems(self, mlist)
-
 	local add = false
 	for k, ply in pairs(player.GetAll()) do
 		local found = false
-
 		for t,v in pairs(mlist:GetCanvas():GetChildren()) do
 			if v.player == ply then
 				found = true
@@ -85,14 +78,15 @@ local function doPlayerItems(self, mlist)
 			add = true
 		end
 	end
-	local del = false
 
+	local del = false
 	for t,v in pairs(mlist:GetCanvas():GetChildren()) do
 		if !v.perm && v.ctime != CurTime() then
 			v:Remove()
 			del = true
 		end
 	end
+
 	-- make sure the rest of the elements are sorted and moved up to fill gaps
 	if del || add then
 		timer.Simple(0, function()
@@ -108,6 +102,7 @@ local function doPlayerItems(self, mlist)
 			for k, v in pairs(childs) do
 				v:SetParent(mlist)
 			end
+
 			mlist:GetCanvas():InvalidateLayout()
 		end)
 	end
@@ -121,6 +116,7 @@ end)
 
 function GM:OpenEndRoundMenu()
 	chat.Close()
+
 	if IsValid(menu) then
 		menu.ChatTextEntry:SetText("")
 		menu:SetVisible(true)
@@ -140,22 +136,21 @@ function GM:OpenEndRoundMenu()
 	menu:ShowCloseButton(false)
 	menu:DockPadding(8, 8, 8, 8)
 
-	local matBlurScreen = Material( "pp/blurscreen" )
+	local matBlurScreen = Material("pp/blurscreen")
 	function menu:Paint(w, h)
 		DisableClipping(true)
 
-		local x, y = self:LocalToScreen( 0, 0 )
-
+		local x, y = self:LocalToScreen(0, 0)
 		local Fraction = 0.4
 
-		surface.SetMaterial( matBlurScreen )
-		surface.SetDrawColor( 255, 255, 255, 255 )
+		surface.SetMaterial(matBlurScreen)
+		surface.SetDrawColor(255, 255, 255, 255)
 
 		for i = 0.33, 1, 0.33 do
-			matBlurScreen:SetFloat( "$blur", Fraction * 5 * i )
+			matBlurScreen:SetFloat("$blur", Fraction * 5 * i)
 			matBlurScreen:Recompute()
-			if ( render ) then render.UpdateScreenEffectTexture() end
-			surface.DrawTexturedRect( x * -1, y * -1, ScrW(), ScrH() )
+			if (render) then render.UpdateScreenEffectTexture() end
+			surface.DrawTexturedRect(x * -1, y * -1, ScrW(), ScrH())
 		end
 
 		surface.SetDrawColor(40,40,40,230)
@@ -166,21 +161,23 @@ function GM:OpenEndRoundMenu()
 
 	local leftpnl = vgui.Create("DPanel", menu)
 	leftpnl:Dock(LEFT)
+
 	function leftpnl:PerformLayout()
 		self:SetWide(menu:GetWide() * 0.4)
 	end
+
 	function leftpnl:Paint(w, h)
 	end
 
 	-- player list section
 	local listpnl = vgui.Create("DPanel", leftpnl)
 	listpnl:Dock(FILL)
+
 	function listpnl:Paint(w, h)
 		surface.SetDrawColor(20, 20, 20, 150)
 		local t = draw.GetFontHeight("RobotoHUD-25") + 2
 		surface.DrawRect(0, t, w, h - t)
 	end
-
 
 	local header = vgui.Create("DLabel", listpnl)
 	header:Dock(TOP)
@@ -192,6 +189,7 @@ function GM:OpenEndRoundMenu()
 	local plist = vgui.Create("DScrollPanel", listpnl)
 	menu.PlayerList = plist
 	plist:Dock(FILL)
+
 	function plist:Paint(w, h)
 	end
 
@@ -199,14 +197,14 @@ function GM:OpenEndRoundMenu()
 		if !self.RefreshWait || self.RefreshWait < CurTime() then
 			self.RefreshWait = CurTime() + 0.1
 			doPlayerItems(self, plist)
-
 		end
 	end
 
 	-- child positioning
 	local canvas = plist:GetCanvas()
 	canvas:DockPadding(0, 0, 0, 0)
-	function canvas:OnChildAdded( child )
+
+	function canvas:OnChildAdded(child)
 		child:Dock(TOP)
 		child:DockMargin(0, 0, 0, 1)
 	end
@@ -215,6 +213,7 @@ function GM:OpenEndRoundMenu()
 	local pnl = vgui.Create("DPanel", leftpnl)
 	pnl:Dock(BOTTOM)
 	pnl:DockMargin(0, 20, 0, 0)
+
 	function pnl:PerformLayout()
 		self:SetTall(leftpnl:GetTall() * 0.5)
 	end
@@ -231,7 +230,6 @@ function GM:OpenEndRoundMenu()
 	header:SetTall(draw.GetFontHeight("RobotoHUD-25"))
 	header:SetText("Chat")
 	header:DockMargin(4, 2, 4, 2)
-
 
 	local sayPnl = vgui.Create("DPanel", pnl)
 	sayPnl:Dock(BOTTOM)
@@ -261,6 +259,7 @@ function GM:OpenEndRoundMenu()
 	menu.ChatTextEntry = entry
 	entry:SetFont("RobotoHUD-15")
 	entry:SetTextColor(color_white)
+
 	function entry:OnEnter(...)
 		RunConsoleCommand("say", self:GetValue())
 		self:SetText("")
@@ -269,44 +268,47 @@ function GM:OpenEndRoundMenu()
 			self:RequestFocus()
 		end)
 	end
+
 	local colCursor = Color(255, 0, 0)
 	local colText = Color(180, 180, 180)
+
 	function entry:Paint(w, h)
-		self:DrawTextEntryText( self.Focused && color_white || colText, self.m_colHighlight, colCursor )
+		self:DrawTextEntryText(self.Focused && color_white || colText, self.m_colHighlight, colCursor)
 	end
+
 	function entry:OnGetFocus()
 		self.Focused = true
 		menu:SetKeyboardInputEnabled(true)
 	end
+
 	function entry:OnLoseFocus()
 		self.Focused = false
 		menu:SetKeyboardInputEnabled(false)
 	end
 
-
 	local mlist = vgui.Create("DScrollPanel", pnl)
 	menu.ChatList = mlist
 	mlist:Dock(FILL)
+
 	function mlist:Paint(w, h)
 	end
 
 	-- child positioning
 	local canvas = mlist:GetCanvas()
 	canvas:DockPadding(0, 0, 0, 0)
-	function canvas:OnChildAdded( child )
+
+	function canvas:OnChildAdded(child)
 		child:Dock(TOP)
 		child:DockMargin(0, 0, 0, 1)
 	end
 
-	function mlist.VBar:SetUp( _barsize_, _canvassize_ )
-
+	function mlist.VBar:SetUp(_barsize_, _canvassize_)
 		local oldSize = self.CanvasSize
 
-		self.BarSize 	= _barsize_
-		self.CanvasSize = math.max( _canvassize_ - _barsize_, 1 )
+		self.BarSize = _barsize_
+		self.CanvasSize = math.max(_canvassize_ - _barsize_, 1)
 
-		self:SetEnabled( _canvassize_ > _barsize_ )
-
+		self:SetEnabled(_canvassize_ > _barsize_)
 		self:InvalidateLayout()
 
 		if self:GetScroll() == oldSize || (oldSize == 1 && self:GetScroll() == 0) then
@@ -320,6 +322,7 @@ function GM:OpenEndRoundMenu()
 	respnl:Dock(FILL)
 	respnl:DockMargin(20, 0, 0, 0)
 	respnl:DockPadding(0, 0, 0, 0)
+
 	function respnl:Paint(w, h)
 		surface.SetDrawColor(20, 20, 20, 150)
 		local t = draw.GetFontHeight("RobotoHUD-25") + 2
@@ -346,6 +349,7 @@ function GM:OpenEndRoundMenu()
 	timeleft:Dock(BOTTOM)
 	timeleft:SetTall(draw.GetFontHeight("RobotoHUD-20"))
 	local col = Color(150, 150, 150)
+
 	function timeleft:Paint(w, h)
 		if GAMEMODE:GetGameState() == ROUND_POST then
 			local settings = GAMEMODE:GetRoundSettings()
@@ -359,12 +363,14 @@ function GM:OpenEndRoundMenu()
 	menu.ResultList = mlist
 	mlist:Dock(FILL)
 	mlist:DockMargin(20, 0, 20, 0)
+
 	function mlist:Paint(w, h)
 	end
 
 	local canvas = mlist:GetCanvas()
 	canvas:DockPadding(0, 0, 0, 0)
-	function canvas:OnChildAdded( child )
+
+	function canvas:OnChildAdded(child)
 		child:Dock(TOP)
 		child:DockMargin(0, 0, 0, 16)
 	end
@@ -376,6 +382,7 @@ function GM:OpenEndRoundMenu()
 	votepnl:Dock(FILL)
 	votepnl:DockMargin(20, 0, 0, 0)
 	votepnl:DockPadding(0, 0, 0, 0)
+
 	function votepnl:Paint(w, h)
 		surface.SetDrawColor(20, 20, 20, 150)
 		local t = draw.GetFontHeight("RobotoHUD-25") + 2
@@ -393,6 +400,7 @@ function GM:OpenEndRoundMenu()
 	timeleft:Dock(BOTTOM)
 	timeleft:SetTall(draw.GetFontHeight("RobotoHUD-20"))
 	local col = Color(150, 150, 150)
+
 	function timeleft:Paint(w, h)
 		if GAMEMODE:GetGameState() == ROUND_MAPVOTE then
 			local voteTime = GAMEMODE.MapVoteTime || 30
@@ -405,12 +413,14 @@ function GM:OpenEndRoundMenu()
 	menu.MapVoteList = mlist
 	mlist:Dock(FILL)
 	mlist:DockMargin(0, 20, 0, 20)
+
 	function mlist:Paint(w, h)
 	end
 
 	local canvas = mlist:GetCanvas()
 	canvas:DockPadding(20, 0, 20, 0)
-	function canvas:OnChildAdded( child )
+
+	function canvas:OnChildAdded(child)
 		child:Dock(TOP)
 		child:DockMargin(0, 0, 0, 16)
 	end
@@ -422,12 +432,11 @@ function GM:CloseEndRoundMenu()
 	end
 end
 
-
 function GM:EndRoundMenuResults(res)
 	self:OpenEndRoundMenu()
+
 	menu.ResultsPanel:SetVisible(true)
 	menu.VotePanel:SetVisible(false)
-
 	menu.Results = res
 	menu.ChatList:Clear()
 	menu.ResultList:Clear()
@@ -442,6 +451,7 @@ function GM:EndRoundMenuResults(res)
 	for _, award in pairs(res.playerAwards) do
 		local pnl = vgui.Create("DPanel")
 		pnl:SetTall(math.max(draw.GetFontHeight("RobotoHUD-35"), draw.GetFontHeight("RobotoHUD-15") + draw.GetFontHeight("RobotoHUD-20") * 1.1))
+
 		function pnl:Paint(w, h)
 			surface.SetDrawColor(50, 50, 50)
 			draw.DrawText(award.name, "RobotoHUD-20", 0, 0, Color(220, 220, 220), 0)
@@ -458,13 +468,13 @@ function GM:EndRoundMapVote()
 
 	menu.ResultsPanel:SetVisible(false)
 	menu.VotePanel:SetVisible(true)
-
 	menu.MapVoteList:Clear()
 
 	for k, map in pairs(self.MapList) do
 		local but = vgui.Create("DButton")
 		but:SetText("")
 		but:SetTall(128)
+
 		local png
 		local path = "maps/" .. map .. ".png"
 		if file.Exists(path, "GAME") then
@@ -480,6 +490,7 @@ function GM:EndRoundMapVote()
 				end
 			end
 		end
+
 		local dname = map:gsub("^%a%a%a?_", ""):gsub("_?v[%d%.%-]+$", "")
 		dname = dname:gsub("[_]", " "):gsub("([%a])([%a]+)", function(a, b) return a:upper() .. b end)
 		local z = tonumber(util.CRC(dname):sub(1, 8))
@@ -488,6 +499,7 @@ function GM:EndRoundMapVote()
 
 		but.VotesScroll = 0
 		but.VotesScrollDir = 1
+
 		function but:Paint(w, h)
 			if self.Hovered then
 				surface.SetDrawColor(50, 50, 50, 50)
@@ -539,6 +551,7 @@ function GM:EndRoundMapVote()
 		function but:DoClick()
 			RunConsoleCommand("ph_votemap", map)
 		end
+
 		menu.MapVoteList:AddItem(but)
 	end
 end
@@ -550,6 +563,7 @@ function GM:EndRoundAddChatText(...)
 
 	local pnl = vgui.Create("DPanel")
 	pnl.Text = {...}
+
 	function pnl:PerformLayout()
 		if self.Text then
 			self.TextLines = WrapText("RobotoHUD-15", self:GetWide() - 16, self.Text)
@@ -564,6 +578,7 @@ function GM:EndRoundAddChatText(...)
 			self.TextLines:Paint(4, draw.GetFontHeight("RobotoHUD-15") * -0.2)
 		end
 	end
+
 	menu.ChatList:AddItem(pnl)
 end
 

--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -18,7 +18,6 @@ local function addPlayerItem(self, mlist, ply)
 	function but:Paint(w, h)
 
 		surface.SetDrawColor(color_black)
-		-- surface.DrawOutlinedRect(0, 0, w, h)
 
 		if IsValid(ply) && ply:IsPlayer() then
 			local col = team.GetColor(ply:Team())
@@ -38,7 +37,6 @@ local function addPlayerItem(self, mlist, ply)
 
 				-- draw mute icon
 				surface.SetDrawColor(255, 255, 255, 255)
-				-- surface.SetDrawColor(255, 255, 255, 255 * math.Clamp(v, 0.1, 1))
 				surface.DrawTexturedRect(s, h / 2 - 16, 32, 32)
 				s = s + 32 + 4
 
@@ -446,7 +444,6 @@ function GM:EndRoundMenuResults(res)
 		pnl:SetTall(math.max(draw.GetFontHeight("RobotoHUD-35"), draw.GetFontHeight("RobotoHUD-15") + draw.GetFontHeight("RobotoHUD-20") * 1.1))
 		function pnl:Paint(w, h)
 			surface.SetDrawColor(50, 50, 50)
-			-- surface.DrawOutlinedRect(0, 0, w, h)
 			draw.DrawText(award.name, "RobotoHUD-20", 0, 0, Color(220, 220, 220), 0)
 			draw.DrawText(award.desc, "RobotoHUD-15", 0, draw.GetFontHeight("RobotoHUD-20"), Color(120, 120, 120), 0)
 			draw.DrawText(award.winnerName, "RobotoHUD-25", w, h / 2 - draw.GetFontHeight("RobotoHUD-25") / 2, team.GetColor(award.winnerTeam), 2)
@@ -563,8 +560,6 @@ function GM:EndRoundAddChatText(...)
 	end
 
 	function pnl:Paint(w, h)
-		-- surface.SetDrawColor(255, 0, 0, 255)
-		-- surface.DrawOutlinedRect(0, 0, w, h)
 		if self.TextLines then
 			self.TextLines:Paint(4, draw.GetFontHeight("RobotoHUD-15") * -0.2)
 		end

--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -149,7 +149,7 @@ function GM:OpenEndRoundMenu()
 		for i = 0.33, 1, 0.33 do
 			matBlurScreen:SetFloat("$blur", Fraction * 5 * i)
 			matBlurScreen:Recompute()
-			if (render) then render.UpdateScreenEffectTexture() end
+			if render then render.UpdateScreenEffectTexture() end
 			surface.DrawTexturedRect(x * -1, y * -1, ScrW(), ScrH())
 		end
 

--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -66,7 +66,7 @@ local function doPlayerItems(self, mlist)
 	local add = false
 	for k, ply in pairs(player.GetAll()) do
 		local found = false
-		for t,v in pairs(mlist:GetCanvas():GetChildren()) do
+		for t, v in pairs(mlist:GetCanvas():GetChildren()) do
 			if v.player == ply then
 				found = true
 				v.ctime = CurTime()
@@ -80,7 +80,7 @@ local function doPlayerItems(self, mlist)
 	end
 
 	local del = false
-	for t,v in pairs(mlist:GetCanvas():GetChildren()) do
+	for t, v in pairs(mlist:GetCanvas():GetChildren()) do
 		if !v.perm && v.ctime != CurTime() then
 			v:Remove()
 			del = true
@@ -153,7 +153,7 @@ function GM:OpenEndRoundMenu()
 			surface.DrawTexturedRect(x * -1, y * -1, ScrW(), ScrH())
 		end
 
-		surface.SetDrawColor(40,40,40,230)
+		surface.SetDrawColor(40, 40, 40, 230)
 		surface.DrawRect(-x, -y, ScrW(), ScrH())
 
 		DisableClipping(false)

--- a/gamemodes/husklesph/gamemode/cl_fixplayercolor.lua
+++ b/gamemodes/husklesph/gamemode/cl_fixplayercolor.lua
@@ -13,32 +13,26 @@ end
 --	}
 
 matproxy.Add({
-	name	=	"PlayerColor",
-
-	init	=	function( self, mat, values )
-
+	name = "PlayerColor",
+	init = function(self, mat, values)
 		-- Store the name of the variable we want to set
 		self.ResultTo = values.resultvar
-
 	end,
+	bind = function(self, mat, ent)
+		if (!IsValid(ent)) then return end
 
-	bind	=	function( self, mat, ent )
-
-		if ( !IsValid( ent ) ) then return end
-
-		if ( ent.GetPlayerColorOverride ) then -- clientside entities can't override functions, so we need an additional one for it
+		if (ent.GetPlayerColorOverride) then -- clientside entities can't override functions, so we need an additional one for it
 			local col = ent:GetPlayerColorOverride()
-			if ( isvector( col ) ) then
-				mat:SetVector( self.ResultTo, col )
+			if (isvector(col)) then
+				mat:SetVector(self.ResultTo, col)
 			end
-		elseif ( ent.GetPlayerColor ) then
+		elseif (ent.GetPlayerColor) then
 			local col = ent:GetPlayerColor()
-			if ( isvector( col ) ) then
-				mat:SetVector( self.ResultTo, col )
+			if (isvector(col)) then
+				mat:SetVector(self.ResultTo, col)
 			end
 		else
-			mat:SetVector( self.ResultTo, Vector( 62.0 / 255.0, 88.0 / 255.0, 106.0 / 255.0 ) )
+			mat:SetVector(self.ResultTo, Vector(62.0 / 255.0, 88.0 / 255.0, 106.0 / 255.0))
 		end
-
 	end
 })

--- a/gamemodes/husklesph/gamemode/cl_fixplayercolor.lua
+++ b/gamemodes/husklesph/gamemode/cl_fixplayercolor.lua
@@ -19,16 +19,16 @@ matproxy.Add({
 		self.ResultTo = values.resultvar
 	end,
 	bind = function(self, mat, ent)
-		if (!IsValid(ent)) then return end
+		if !IsValid(ent) then return end
 
-		if (ent.GetPlayerColorOverride) then -- clientside entities can't override functions, so we need an additional one for it
+		if ent.GetPlayerColorOverride then -- clientside entities can't override functions, so we need an additional one for it
 			local col = ent:GetPlayerColorOverride()
-			if (isvector(col)) then
+			if isvector(col) then
 				mat:SetVector(self.ResultTo, col)
 			end
-		elseif (ent.GetPlayerColor) then
+		elseif ent.GetPlayerColor then
 			local col = ent:GetPlayerColor()
-			if (isvector(col)) then
+			if isvector(col) then
 				mat:SetVector(self.ResultTo, col)
 			end
 		else

--- a/gamemodes/husklesph/gamemode/cl_helpscreen.lua
+++ b/gamemodes/husklesph/gamemode/cl_helpscreen.lua
@@ -1,8 +1,6 @@
-
 local categories = {}
 
 local function addHelpText(heading, size, text, color)
-
 	local t = {}
 	t.heading = heading
 	t.size = size || 1
@@ -11,7 +9,6 @@ local function addHelpText(heading, size, text, color)
 	t.color = color
 	table.insert(categories, t)
 end
-
 
 addHelpText("Intro", 1, [[
 == CONTROLS ==
@@ -39,6 +36,7 @@ local function colMul(color, mul)
 end
 
 local menu
+
 local function openHelpScreen()
 	if IsValid(menu) then
 		menu:SetVisible(!menu:IsVisible())
@@ -54,33 +52,35 @@ local function openHelpScreen()
 		menu:ShowCloseButton(true)
 		menu:SetTitle("")
 		menu:DockPadding(8, 8 + draw.GetFontHeight("RobotoHUD-25"), 8, 8)
+
 		function menu:PerformLayout()
 		end
 
 		function menu:Paint(w, h)
 			surface.SetDrawColor(40,40,40,230)
 			surface.DrawRect(0, 0, w, h)
-
 			surface.SetFont("RobotoHUD-25")
+
 			local t = "Help"
 			local tw,th = surface.GetTextSize(t)
 			draw.ShadowText(t, "RobotoHUD-25", 8, 2, Color(132, 199, 29), 0)
-
 			draw.ShadowText("learn about the gamemode", "RobotoHUD-L15", 8 + tw + 16, 2 + th * 0.90, Color(220, 220, 220), 0, 4)
 		end
 
 		local catlist = vgui.Create("DScrollPanel", menu)
 		catlist:Dock(LEFT)
 		catlist:SetWide(200)
+
 		function catlist:Paint(w, h)
 		end
 
 		-- child positioning
 		local canvas = catlist:GetCanvas()
 		canvas:DockPadding(0, 0, 0, 0)
-		function canvas:OnChildAdded( child )
-			child:Dock( TOP )
-			child:DockMargin( 0,0,0,4 )
+
+		function canvas:OnChildAdded(child)
+			child:Dock(TOP)
+			child:DockMargin(0,0,0,4)
 		end
 
 		for k, t in pairs(categories) do
@@ -88,10 +88,12 @@ local function openHelpScreen()
 			if t.size == 2 then
 				font = "RobotoHUD-15"
 			end
+
 			local but = vgui.Create("DButton")
 			but:SetText("")
 			but:SetTall(draw.GetFontHeight(font) * 1.2)
 			but.Selected = false
+
 			function but:Paint(w, h)
 				local col = Color(68, 68, 68, 160)
 				local colt = Color(190, 190, 190)
@@ -107,23 +109,23 @@ local function openHelpScreen()
 				end
 
 				draw.RoundedBoxEx(4, 0, 0, w, h, col, true, false, true, false)
-
 				draw.ShadowText(t.heading, font, w / 2, h / 2, colt, 1, 1)
 			end
+
 			function but:DoClick()
 				menu.TextContent.Text = t.text
 				menu.TextContent:InvalidateLayout()
 			end
+
 			catlist:AddItem(but)
 		end
 
-
 		local textscroll = vgui.Create("DScrollPanel", menu)
 		textscroll:Dock(FILL)
+
 		function textscroll:Paint(w, h)
 			surface.SetDrawColor(68, 68, 68, 160)
 			surface.DrawOutlinedRect(0, 0, w, h)
-
 			surface.SetDrawColor(55, 55, 55, 120)
 			surface.DrawRect(1, 1, w - 2, h - 2)
 		end
@@ -131,9 +133,10 @@ local function openHelpScreen()
 		-- child positioning
 		local canvas = textscroll:GetCanvas()
 		canvas:DockPadding(0, 0, 0, 0)
-		function canvas:OnChildAdded( child )
-			child:Dock( TOP )
-			child:DockMargin( 0,0,0,4 )
+
+		function canvas:OnChildAdded(child)
+			child:Dock(TOP)
+			child:DockMargin(0,0,0,4)
 		end
 
 		local pnl = vgui.Create("DPanel")
@@ -142,10 +145,12 @@ local function openHelpScreen()
 		pnl.Text = categories[1].text
 		catlist:GetCanvas():GetChildren()[1].Selected = true
 		textscroll:AddItem(pnl)
+
 		function pnl:PerformLayout()
 			if self.Text then
 				self.TextLines = WrapText("RobotoHUD-L15", self:GetWide() - 16, {self.Text})
 			end
+
 			if self.TextLines then
 				local y = self.TextLines.height
 				self:SetTall(y + 8)

--- a/gamemodes/husklesph/gamemode/cl_helpscreen.lua
+++ b/gamemodes/husklesph/gamemode/cl_helpscreen.lua
@@ -57,12 +57,12 @@ local function openHelpScreen()
 		end
 
 		function menu:Paint(w, h)
-			surface.SetDrawColor(40,40,40,230)
+			surface.SetDrawColor(40, 40, 40, 230)
 			surface.DrawRect(0, 0, w, h)
 			surface.SetFont("RobotoHUD-25")
 
 			local t = "Help"
-			local tw,th = surface.GetTextSize(t)
+			local tw, th = surface.GetTextSize(t)
 			draw.ShadowText(t, "RobotoHUD-25", 8, 2, Color(132, 199, 29), 0)
 			draw.ShadowText("learn about the gamemode", "RobotoHUD-L15", 8 + tw + 16, 2 + th * 0.90, Color(220, 220, 220), 0, 4)
 		end
@@ -80,7 +80,7 @@ local function openHelpScreen()
 
 		function canvas:OnChildAdded(child)
 			child:Dock(TOP)
-			child:DockMargin(0,0,0,4)
+			child:DockMargin(0, 0, 0, 4)
 		end
 
 		for k, t in pairs(categories) do
@@ -136,7 +136,7 @@ local function openHelpScreen()
 
 		function canvas:OnChildAdded(child)
 			child:Dock(TOP)
-			child:DockMargin(0,0,0,4)
+			child:DockMargin(0, 0, 0, 4)
 		end
 
 		local pnl = vgui.Create("DPanel")

--- a/gamemodes/husklesph/gamemode/cl_helpscreen.lua
+++ b/gamemodes/husklesph/gamemode/cl_helpscreen.lua
@@ -53,7 +53,6 @@ local function openHelpScreen()
 		menu:SetDraggable(false)
 		menu:ShowCloseButton(true)
 		menu:SetTitle("")
-		-- menu:DockPadding(0, 0, 0, 0)
 		menu:DockPadding(8, 8 + draw.GetFontHeight("RobotoHUD-25"), 8, 8)
 		function menu:PerformLayout()
 		end
@@ -154,8 +153,6 @@ local function openHelpScreen()
 		end
 
 		function pnl:Paint(w, h)
-			-- surface.SetDrawColor(0, 0, 0, 255)
-			-- surface.DrawOutlinedRect(0, 0, w, h)
 			if self.TextLines then
 				self.TextLines:Paint(8, 4)
 			end

--- a/gamemodes/husklesph/gamemode/cl_hud.lua
+++ b/gamemodes/husklesph/gamemode/cl_hud.lua
@@ -174,7 +174,7 @@ function GM:DrawHealth(ply)
 	surface.SetDrawColor(26, 120, 245, 1)
 	drawPoly(x + w * ps, y + h * ps, w * (1 - 2 * ps), h * (1 - 2 * ps), 1)
 
-	render.SetStencilEnable(true);
+	render.SetStencilEnable(true)
 	render.SetStencilCompareFunction(STENCILCOMPARISONFUNCTION_EQUAL)
 	render.SetStencilPassOperation(STENCILOPERATION_REPLACE)
 	render.SetStencilReferenceValue(1)
@@ -190,9 +190,9 @@ function GM:DrawHealth(ply)
 	draw.ShadowText(math.Round(health) .. "", "RobotoHUD-25", x + w / 2, y + h / 2, color_white, 1, 1)
 
 	render.SetStencilEnable(false)
-	render.SetStencilWriteMask(0);
-	render.SetStencilReferenceValue(0);
-	render.SetStencilTestMask(0);
+	render.SetStencilWriteMask(0)
+	render.SetStencilReferenceValue(0)
+	render.SetStencilTestMask(0)
 	render.SetStencilEnable(false)
 	render.OverrideDepthEnable(false)
 	render.SetBlend(1)

--- a/gamemodes/husklesph/gamemode/cl_hud.lua
+++ b/gamemodes/husklesph/gamemode/cl_hud.lua
@@ -30,8 +30,6 @@ end
 
 function GM:HUDPaint()
 	self:DrawGameHUD()
-	-- DebugInfo(1, tostring(LocalPlayer():GetVelocity():Length()))
-
 	self:DrawRoundTimer()
 	self:DrawKillFeed()
 end
@@ -132,8 +130,6 @@ local function drawPoly(x, y, w, h, percent)
 		table.insert(vertexes, {x = x + w / 2, y = y + h})
 		table.insert(vertexes, {x = x + w / 2, y = y + h / 2})
 
-		-- for i = 1, #vertexes do draw.DrawText(i, "Default", vertexes[i].x, vertexes[i].y, color_white, 0) end
-
 		surface.SetTexture(polyTex)
 		surface.DrawPoly(vertexes)
 	end
@@ -151,8 +147,6 @@ local function drawPoly(x, y, w, h, percent)
 	end
 	table.insert(vertexes, {x = x + w / 2, y = y})
 	table.insert(vertexes, {x = x + w / 2, y = y + h / 2})
-
-	-- for i = 1, #vertexes do draw.DrawText(i, "Default", vertexes[i].x, vertexes[i].y, color_white, 0) end
 
 	surface.SetTexture(polyTex)
 	surface.DrawPoly(vertexes)
@@ -182,7 +176,6 @@ function GM:DrawHealth(ply)
 	render.SetBlend( 0 )
 
 	render.OverrideDepthEnable( true, false )
-	-- render.DrawScreenQuadEx(tx, ty, tw, th)
 
 	surface.SetDrawColor(26, 120, 245, 1)
 	drawPoly(x + w * ps, y + h * ps, w * (1 - 2 * ps), h * (1 - 2 * ps), 1)
@@ -226,7 +219,6 @@ function GM:HUDShouldDraw(name)
 	if name == "CHudHealth" then return false end
 	if name == "CHudVoiceStatus" then return false end
 	if name == "CHudVoiceSelfStatus" then return false end
-	-- if name == "CHudAmmo" then return false end
 	if name == "CHudChat" then
 		if IsValid(self.EndRoundPanel) && self.EndRoundPanel:IsVisible() then
 			return false

--- a/gamemodes/husklesph/gamemode/cl_hud.lua
+++ b/gamemodes/husklesph/gamemode/cl_hud.lua
@@ -151,7 +151,7 @@ end
 
 function GM:DrawHealth(ply)
 	local x = 20
-	local w,h = math.ceil(ScrW() * 0.09), 80
+	local w, h = math.ceil(ScrW() * 0.09), 80
 	h = w
 	local y = ScrH() - 20 - h
 	local ps = 0.05

--- a/gamemodes/husklesph/gamemode/cl_hud.lua
+++ b/gamemodes/husklesph/gamemode/cl_hud.lua
@@ -1,14 +1,13 @@
-
-
 local function createRoboto(s)
-	surface.CreateFont( "RobotoHUD-" .. s , {
+	surface.CreateFont("RobotoHUD-" .. s , {
 		font = "Roboto-Bold",
 		size = math.Round(ScrW() / 1000 * s),
 		weight = 700,
 		antialias = true,
 		italic = false
 	})
-	surface.CreateFont( "RobotoHUD-L" .. s , {
+
+	surface.CreateFont("RobotoHUD-L" .. s , {
 		font = "Roboto",
 		size = math.Round(ScrW() / 1000 * s),
 		weight = 500,
@@ -50,6 +49,7 @@ function GM:DrawGameHUD()
 	if self:IsCSpectating() && IsValid(self:GetCSpectatee()) && self:GetCSpectatee():IsPlayer() then
 		ply = self:GetCSpectatee()
 	end
+
 	self:DrawHealth(ply)
 
 	if ply != LocalPlayer() then
@@ -57,9 +57,7 @@ function GM:DrawGameHUD()
 		draw.ShadowText(ply:Nick(), "RobotoHUD-30", ScrW() / 2, ScrH() - 4, col, 1, 4)
 	end
 
-
 	local tr = ply:GetEyeTraceNoCursor()
-
 	local shouldDraw = hook.Run("HUDShouldDraw", "PropHuntersPlayerNames")
 	if shouldDraw != false then
 		-- draw names
@@ -70,6 +68,7 @@ function GM:DrawGameHUD()
 				self.LookedFade = CurTime()
 			end
 		end
+
 		if IsValid(self.LastLooked) && self.LookedFade + 2 > CurTime() then
 			local name = self.LastLooked:Nick() || "error"
 			local col = table.Copy(team.GetColor(self.LastLooked:Team()))
@@ -77,7 +76,6 @@ function GM:DrawGameHUD()
 			draw.ShadowText(name, "RobotoHUD-20", ScrW() / 2, ScrH() / 2 + 80, col, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, Color(0, 0, 0, col.a))
 		end
 	end
-
 
 	local help
 	if LocalPlayer():Alive() then
@@ -88,14 +86,11 @@ function GM:DrawGameHUD()
 		end
 	end
 
-
-
 	if help then
 		local fh = draw.GetFontHeight("RobotoHUD-L15")
 		local h = #help * fh
 		local x = 20
 		local y = ScrH() / 2 - h / 2
-
 		local i = 0
 		local tw = 0
 		for k, t in pairs(help) do
@@ -104,6 +99,7 @@ function GM:DrawGameHUD()
 			local w = surface.GetTextSize(name)
 			tw = math.max(tw, w)
 		end
+
 		for k, t in pairs(help) do
 			surface.SetFont("RobotoHUD-15")
 			local name = keyName(t[1])
@@ -118,7 +114,6 @@ local polyTex = surface.GetTextureID("VGUI/white.vmt")
 
 local function drawPoly(x, y, w, h, percent)
 	local points = 40
-
 	if percent > 0.5 then
 		local vertexes = {}
 		local hpoints = points / 2
@@ -127,6 +122,7 @@ local function drawPoly(x, y, w, h, percent)
 		for i = (1 - percent) * 2 * hpoints, hpoints do
 			table.insert(vertexes, {x = x + w / 2 + math.cos(i * mul + base) * w / 2, y = y + h / 2 + math.sin(i * mul + base) * h / 2})
 		end
+
 		table.insert(vertexes, {x = x + w / 2, y = y + h})
 		table.insert(vertexes, {x = x + w / 2, y = y + h / 2})
 
@@ -140,8 +136,9 @@ local function drawPoly(x, y, w, h, percent)
 	local mul = 1 / hpoints * math.pi
 	local p = 0
 	if percent < 0.5 then
-		p = (1 - percent * 2 )
+		p = (1 - percent * 2)
 	end
+
 	for i = p * hpoints, hpoints do
 		table.insert(vertexes, {x = x + w / 2 + math.cos(i * mul + base) * w / 2, y = y + h / 2 + math.sin(i * mul + base) * h / 2})
 	end
@@ -157,37 +154,33 @@ function GM:DrawHealth(ply)
 	local w,h = math.ceil(ScrW() * 0.09), 80
 	h = w
 	local y = ScrH() - 20 - h
-
 	local ps = 0.05
 
 	surface.SetDrawColor(50, 50, 50, 180)
 	drawPoly(x, y, w, h, 1)
 
 	render.ClearStencil()
-	render.SetStencilEnable( true )
-	render.SetStencilFailOperation( STENCILOPERATION_KEEP )
-	render.SetStencilZFailOperation( STENCILOPERATION_KEEP )
-	render.SetStencilPassOperation( STENCILOPERATION_REPLACE )
-	render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_ALWAYS )
-	render.SetStencilWriteMask( 1 )
-	render.SetStencilTestMask( 1 )
-	render.SetStencilReferenceValue( 1 )
-
-	render.SetBlend( 0 )
-
-	render.OverrideDepthEnable( true, false )
+	render.SetStencilEnable(true)
+	render.SetStencilFailOperation(STENCILOPERATION_KEEP)
+	render.SetStencilZFailOperation(STENCILOPERATION_KEEP)
+	render.SetStencilPassOperation(STENCILOPERATION_REPLACE)
+	render.SetStencilCompareFunction(STENCILCOMPARISONFUNCTION_ALWAYS)
+	render.SetStencilWriteMask(1)
+	render.SetStencilTestMask(1)
+	render.SetStencilReferenceValue(1)
+	render.SetBlend(0)
+	render.OverrideDepthEnable(true, false)
 
 	surface.SetDrawColor(26, 120, 245, 1)
 	drawPoly(x + w * ps, y + h * ps, w * (1 - 2 * ps), h * (1 - 2 * ps), 1)
 
-	render.SetStencilEnable( true );
-	render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_EQUAL )
-	render.SetStencilPassOperation( STENCILOPERATION_REPLACE )
-	render.SetStencilReferenceValue( 1 )
+	render.SetStencilEnable(true);
+	render.SetStencilCompareFunction(STENCILCOMPARISONFUNCTION_EQUAL)
+	render.SetStencilPassOperation(STENCILOPERATION_REPLACE)
+	render.SetStencilReferenceValue(1)
 
 	local health = ply:Health()
 	local maxhealth = math.max(health, ply:GetHMaxHealth())
-
 	local nh = math.Round((h - ps * 2) * math.Clamp(health / maxhealth, 0, 1))
 	local tcol = table.Copy(team.GetColor(ply:Team()))
 	tcol.a = 150
@@ -196,17 +189,15 @@ function GM:DrawHealth(ply)
 
 	draw.ShadowText(math.Round(health) .. "", "RobotoHUD-25", x + w / 2, y + h / 2, color_white, 1, 1)
 
+	render.SetStencilEnable(false)
+	render.SetStencilWriteMask(0);
+	render.SetStencilReferenceValue(0);
+	render.SetStencilTestMask(0);
+	render.SetStencilEnable(false)
+	render.OverrideDepthEnable(false)
+	render.SetBlend(1)
 
-	render.SetStencilEnable( false )
-
-	render.SetStencilWriteMask( 0 );
-		render.SetStencilReferenceValue( 0 );
-		render.SetStencilTestMask( 0 );
-		render.SetStencilEnable( false )
-		render.OverrideDepthEnable( false )
-		render.SetBlend( 1 )
-
-		cam.IgnoreZ( false )
+	cam.IgnoreZ(false)
 
 	if ply:IsDisguised() && ply:DisguiseRotationLocked() then
 		local fg = draw.GetFontHeight("RobotoHUD-15")
@@ -224,6 +215,7 @@ function GM:HUDShouldDraw(name)
 			return false
 		end
 	end
+
 	return true
 end
 
@@ -244,6 +236,7 @@ function GM:DrawRoundTimer()
 		if self:GetStateRunningTime() < 2 then
 			draw.ShadowText("GO!", "RobotoHUD-50", ScrW() / 2, ScrH() / 3, color_white, 1, 1)
 		end
+
 		local settings = self:GetRoundSettings()
 		local roundTime = settings.RoundTime || 5 * 60
 		local time = math.max(0, roundTime - self:GetStateRunningTime())

--- a/gamemodes/husklesph/gamemode/cl_init.lua
+++ b/gamemodes/husklesph/gamemode/cl_init.lua
@@ -28,9 +28,9 @@ function GM:InitPostEntity()
 end
 
 function GM:PostDrawViewModel(vm, ply, weapon)
-	if (weapon.UseHands || !weapon:IsScripted()) then
+	if weapon.UseHands || !weapon:IsScripted() then
 		local hands = LocalPlayer():GetHands()
-		if (IsValid(hands)) then hands:DrawModel() end
+		if IsValid(hands) then hands:DrawModel() end
 	end
 end
 

--- a/gamemodes/husklesph/gamemode/cl_init.lua
+++ b/gamemodes/husklesph/gamemode/cl_init.lua
@@ -27,25 +27,21 @@ function GM:InitPostEntity()
 	net.SendToServer()
 end
 
-function GM:PostDrawViewModel( vm, ply, weapon )
-
-	if ( weapon.UseHands || !weapon:IsScripted() ) then
-
+function GM:PostDrawViewModel(vm, ply, weapon)
+	if (weapon.UseHands || !weapon:IsScripted()) then
 		local hands = LocalPlayer():GetHands()
-		if ( IsValid( hands ) ) then hands:DrawModel() end
-
+		if (IsValid(hands)) then hands:DrawModel() end
 	end
-
 end
 
-function GM:RenderScene( origin, angles, fov )
+function GM:RenderScene(origin, angles, fov)
 	local client = LocalPlayer()
 	if IsValid(client) then
 		local wep = client:GetActiveWeapon()
 		if IsValid(wep) && wep.PostDrawTranslucentRenderables then
 			local errored, retval = pcall(wep.PostDrawTranslucentRenderables, wep)
 			if !errored then
-				print( retval )
+				print(retval)
 			end
 		end
 	end
@@ -59,6 +55,7 @@ local function lerp(from, to, step)
 	if from < to then
 		return math.min(from + step, to)
 	end
+
 	return math.max(from - step, to)
 end
 
@@ -67,19 +64,21 @@ function GM:CalcView(ply, pos, angles, fov)
 	if self:IsCSpectating() && IsValid(self:GetCSpectatee()) then
 		ply = self:GetCSpectatee()
 	end
+
 	if ply:IsPlayer() && !ply:Alive() then
 		ply = ply:GetRagdollEntity()
 	end
+
 	if IsValid(ply) then
 		if ply:IsPlayer() && ply:IsDisguised() then
 			local maxs = ply:GetNWVector("disguiseMaxs")
 			local mins = ply:GetNWVector("disguiseMins")
 			local view = {}
-
 			local reach = (maxs.z - mins.z)
 			if self:GetRoundSettings() && self:GetRoundSettings().PropsCamDistance then
 				reach = reach * self:GetRoundSettings().PropsCamDistance
 			end
+
 			local trace = {}
 			trace.start = ply:GetPropEyePos()
 			trace.endpos = trace.start + angles:Forward() * -reach
@@ -117,7 +116,6 @@ net.Receive("hull_set", function(len)
 	GAMEMODE:PlayerSetHull(ply, hullx, hully, hullz, duckz)
 end)
 
-
 function GM:RenderScene()
 	self:RenderDisguises()
 end
@@ -143,7 +141,6 @@ end)
 function GM:StartChat()
 	if IsValid(self.EndRoundPanel) && self.EndRoundPanel:IsVisible() then
 		timer.Simple(0, function() chat.Close() end)
-
 		self.EndRoundPanel:SetKeyboardInputEnabled(true)
 		self.EndRoundPanel.ChatTextEntry:RequestFocus()
 		return true

--- a/gamemodes/husklesph/gamemode/cl_init.lua
+++ b/gamemodes/husklesph/gamemode/cl_init.lua
@@ -96,8 +96,6 @@ function GM:CalcView(ply, pos, angles, fov)
 			local camPos = trace.start * 1
 			camPos.z = ply:GetPos().z + camHeight
 			view.origin = camPos + (trace.endpos - trace.start):GetNormal() * camDis
-			-- view.origin = tr.HitPos
-
 			view.angles = angles
 			view.fov = fov
 			return view

--- a/gamemodes/husklesph/gamemode/cl_init.lua
+++ b/gamemodes/husklesph/gamemode/cl_init.lua
@@ -59,7 +59,7 @@ local function lerp(from, to, step)
 	return math.max(from - step, to)
 end
 
-local camDis, camHeight = 0,0
+local camDis, camHeight = 0, 0
 function GM:CalcView(ply, pos, angles, fov)
 	if self:IsCSpectating() && IsValid(self:GetCSpectatee()) then
 		ply = self:GetCSpectatee()

--- a/gamemodes/husklesph/gamemode/cl_killfeed.lua
+++ b/gamemodes/husklesph/gamemode/cl_killfeed.lua
@@ -1,6 +1,5 @@
 GM.KillFeed = {}
 
-
 net.Receive("kill_feed_add", function(len)
 	local ply = net.ReadEntity()
 	local attacker = net.ReadEntity()
@@ -18,6 +17,7 @@ net.Receive("kill_feed_add", function(len)
 		t.message = "pushed to their death"
 		t.messageSelf = "fell to their death"
 	end
+
 	if bit.band(damageType, DMG_BULLET) == DMG_BULLET then
 		t.message = table.Random({
 			"shot",
@@ -26,23 +26,28 @@ net.Receive("kill_feed_add", function(len)
 		})
 		t.messageSelf = "shot themself"
 	end
+
 	if bit.band(damageType, DMG_BURN) == DMG_BURN then
 		t.message = "burned to death"
 		t.messageSelf = "burned to death"
 	end
+
 	if bit.band(damageType, DMG_CRUSH) == DMG_CRUSH then
 		t.message = "threw a prop at"
 		t.messageSelf = "was crushed to death"
 	end
+
 	if bit.band(damageType, DMG_BUCKSHOT) == DMG_BUCKSHOT then
 		t.message = table.Random({
 			"peppered with buckshot",
 			"shotgunned",
 		})
 	end
+
 	if bit.band(damageType, DMG_AIRBOAT) == DMG_AIRBOAT then
 		t.messageSelf = "shot too many props"
 	end
+
 	if damageType == 0 then
 		t.messageSelf = table.Random({
 			"fell over",
@@ -51,6 +56,7 @@ net.Receive("kill_feed_add", function(len)
 			"killed themself"
 		})
 	end
+
 	if IsValid(attacker) && attacker:IsPlayer() && attacker != ply then
 		t.attackerName = attacker:Nick()
 		t.attackerColor = team.GetColor(attacker:Team())
@@ -70,13 +76,13 @@ function GM:DrawKillFeed()
 		if k > #GAMEMODE.KillFeed then
 			break
 		end
+
 		local t = GAMEMODE.KillFeed[k]
 		if t.time + 30 < CurTime() then
 			table.remove(self.KillFeed, k)
 		else
 			surface.SetFont("RobotoHUD-15")
 			local twp = surface.GetTextSize(t.playerName)
-
 			if t.attackerName then
 				local killed = " " .. (t.message || "killed") .. " "
 				local twa = surface.GetTextSize(t.attackerName)
@@ -87,7 +93,6 @@ function GM:DrawKillFeed()
 			else
 				local killed = " " .. (t.messageSelf || "killed themself")
 				local twk = surface.GetTextSize(killed)
-
 				draw.ShadowText(killed, "RobotoHUD-15", ScrW() - 4 - twk, 4 + down * gap, color_white, 0)
 				draw.ShadowText(t.playerName, "RobotoHUD-15", ScrW() - 4 - twp - twk, 4 + down * gap, t.playerColor, 0)
 			end
@@ -97,4 +102,3 @@ function GM:DrawKillFeed()
 		end
 	end
 end
-

--- a/gamemodes/husklesph/gamemode/cl_mapvote.lua
+++ b/gamemodes/husklesph/gamemode/cl_mapvote.lua
@@ -6,7 +6,6 @@ net.Receive("ph_mapvote", function(len)
 	GAMEMODE.MapVoteTime = net.ReadFloat()
 
 	local mapList = {}
-
 	while true do
 		local k = net.ReadUInt(16)
 		if k <= 0 then break end
@@ -23,9 +22,7 @@ net.Receive("ph_mapvote", function(len)
 end)
 
 net.Receive("ph_mapvotevotes", function(len)
-
 	local mapVotes = {}
-
 	while true do
 		local k = net.ReadUInt(8)
 		if k <= 0 then break end

--- a/gamemodes/husklesph/gamemode/cl_ragdoll.lua
+++ b/gamemodes/husklesph/gamemode/cl_ragdoll.lua
@@ -4,21 +4,25 @@ local EntityMeta = FindMetaTable("Entity")
 if !PlayerMeta.GetRagdollEntityOld then
 	PlayerMeta.GetRagdollEntityOld = PlayerMeta.GetRagdollEntity
 end
+
 function PlayerMeta:GetRagdollEntity()
 	local ent = self:GetNWEntity("DeathRagdoll")
 	if IsValid(ent) then
 		return ent
 	end
+
 	return self:GetRagdollEntityOld()
 end
 
 if !EntityMeta.GetRagdollOwnerOld then
 	EntityMeta.GetRagdollOwnerOld = EntityMeta.GetRagdollOwner
 end
+
 function EntityMeta:GetRagdollOwner()
 	local ent = self:GetNWEntity("RagdollOwner")
 	if IsValid(ent) then
 		return ent
 	end
+
 	return self:GetRagdollOwnerOld()
 end

--- a/gamemodes/husklesph/gamemode/cl_rounds.lua
+++ b/gamemodes/husklesph/gamemode/cl_rounds.lua
@@ -43,7 +43,6 @@ net.Receive("round_victor", function(len)
 end)
 
 net.Receive("gamerules", function()
-
 	local settings = {}
 	while net.ReadUInt(8) != 0 do
 		local k = net.ReadString()

--- a/gamemodes/husklesph/gamemode/cl_scoreboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_scoreboard.lua
@@ -33,7 +33,6 @@ local function addPlayerItem(self, mlist, ply, pteam)
 	function but:Paint(w, h)
 
 		surface.SetDrawColor(color_black)
-		-- surface.DrawOutlinedRect(0, 0, w, h)
 
 		if IsValid(ply) && ply:IsPlayer() then
 			local s = 4
@@ -47,10 +46,6 @@ local function addPlayerItem(self, mlist, ply, pteam)
 
 			if ply:IsMuted() then
 				surface.SetMaterial(muted)
-
-				-- draw shadow
-				-- surface.SetDrawColor(color_black)
-				-- surface.DrawTexturedRect(s + 1, h / 2 - 16 + 1, 32, 32)
 
 				-- draw mute icon
 				surface.SetDrawColor(150, 150, 150, 255)
@@ -112,8 +107,6 @@ local function makeTeamList(parent, pteam)
 	local hs = math.Round(draw.GetFontHeight("RobotoHUD-25") * 1.1)
 	function pnl:Paint(w, h)
 		surface.SetDrawColor(220, 220, 220, 50)
-		-- surface.DrawRect(0, 0, w, h)
-
 		surface.SetDrawColor(68, 68, 68, 120)
 		surface.DrawLine(0, hs, 0, h - 1)
 		surface.DrawLine(w - 1, hs, w - 1, h - 1)
@@ -137,10 +130,7 @@ local function makeTeamList(parent, pteam)
 	headp:SetTall(hs)
 	function headp:Paint(w, h)
 		surface.SetDrawColor(68, 68, 68, 255)
-		-- surface.DrawRect(0, 0, w, h)
-
 		draw.RoundedBoxEx(4, 0, 0, w, h, Color(68, 68, 68, 120), true, true, false, false)
-
 		draw.ShadowText(team.GetName(pteam), "RobotoHUD-25", 6, 0, team.GetColor(pteam), 0)
 	end
 
@@ -155,20 +145,16 @@ local function makeTeamList(parent, pteam)
 	end
 	function but:Paint(w, h)
 		surface.SetDrawColor(team.GetColor(pteam))
-		-- surface.DrawRect(0, 0, w, h)
 		surface.SetDrawColor(color_black)
-		-- surface.DrawOutlinedRect(0, 0, w, h)
 
 		local col = table.Copy(team.GetColor(pteam))
 		if self:IsDown() then
 			surface.SetDrawColor(12,50,50,120)
-			-- surface.DrawRect(1, 1, w - 2, h - 2)
 			col.r = col.r * 0.8
 			col.g = col.g * 0.8
 			col.b = col.b * 0.8
 		elseif self:IsHovered() then
 			surface.SetDrawColor(255,255,255,30)
-			-- surface.DrawRect(1, 1, w - 2, h - 2)
 			col.r = col.r * 1.2
 			col.g = col.g * 1.2
 			col.b = col.b * 1.2
@@ -307,7 +293,6 @@ function GM:ScoreboardShow()
 		main:Dock(FILL)
 		function main:Paint(w, h)
 			surface.SetDrawColor(40,40,40,230)
-			-- surface.DrawRect(0, 0, w, h)
 		end
 
 		menu.CopsList = makeTeamList(main, TEAM_HUNTER)

--- a/gamemodes/husklesph/gamemode/cl_scoreboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_scoreboard.lua
@@ -4,7 +4,7 @@ end
 
 local menu
 
-surface.CreateFont( "ScoreboardPlayer" , {
+surface.CreateFont("ScoreboardPlayer" , {
 	font = "coolvetica",
 	size = 32,
 	weight = 500,
@@ -18,12 +18,10 @@ local function colMul(color, mul)
 	color.b = math.Clamp(math.Round(color.b * mul), 0, 255)
 end
 
-
 local muted = Material("icon32/muted.png", "noclamp")
 local skull = Material("melonbomber/skull.png", "noclamp")
 
 local function addPlayerItem(self, mlist, ply, pteam)
-
 	local but = vgui.Create("DButton")
 	but.player = ply
 	but.ctime = CurTime()
@@ -31,12 +29,10 @@ local function addPlayerItem(self, mlist, ply, pteam)
 	but:SetText("")
 
 	function but:Paint(w, h)
-
 		surface.SetDrawColor(color_black)
 
 		if IsValid(ply) && ply:IsPlayer() then
 			local s = 4
-
 			if !ply:Alive() then
 				surface.SetMaterial(skull)
 				surface.SetDrawColor(220, 220, 220, 255)
@@ -55,7 +51,6 @@ local function addPlayerItem(self, mlist, ply, pteam)
 
 			local col = color_white
 			draw.ShadowText(ply:Ping(), "RobotoHUD-L20", w - 4, 0, col, 2)
-
 			draw.ShadowText(ply:Nick(), "RobotoHUD-L20", s, 0, col, 0)
 		end
 	end
@@ -70,10 +65,8 @@ local function addPlayerItem(self, mlist, ply, pteam)
 end
 
 local function doPlayerItems(self, mlist, pteam)
-
 	for k, ply in pairs(team.GetPlayers(pteam)) do
 		local found = false
-
 		for t,v in pairs(mlist:GetCanvas():GetChildren()) do
 			if v.player == ply then
 				found = true
@@ -85,14 +78,15 @@ local function doPlayerItems(self, mlist, pteam)
 			addPlayerItem(self, mlist, ply, pteam)
 		end
 	end
-	local del = false
 
+	local del = false
 	for t,v in pairs(mlist:GetCanvas():GetChildren()) do
 		if !v.perm && v.ctime != CurTime() then
 			v:Remove()
 			del = true
 		end
 	end
+
 	-- make sure the rest of the elements are moved up
 	if del then
 		timer.Simple(0, function() mlist:GetCanvas():InvalidateLayout() end)
@@ -103,15 +97,14 @@ local function makeTeamList(parent, pteam)
 	local mlist
 	local pnl = vgui.Create("DPanel", parent)
 	pnl:DockPadding(0, 0, 0, 0)
-
 	local hs = math.Round(draw.GetFontHeight("RobotoHUD-25") * 1.1)
+
 	function pnl:Paint(w, h)
 		surface.SetDrawColor(220, 220, 220, 50)
 		surface.SetDrawColor(68, 68, 68, 120)
 		surface.DrawLine(0, hs, 0, h - 1)
 		surface.DrawLine(w - 1, hs, w - 1, h - 1)
 		surface.DrawLine(0, h - 1, w, h - 1)
-
 		surface.SetDrawColor(55, 55, 55, 120)
 		surface.DrawRect(1, hs, w - 2, h - hs)
 	end
@@ -120,7 +113,6 @@ local function makeTeamList(parent, pteam)
 		if !self.RefreshWait || self.RefreshWait < CurTime() then
 			self.RefreshWait = CurTime() + 0.1
 			doPlayerItems(self, mlist, pteam)
-
 		end
 	end
 
@@ -128,6 +120,7 @@ local function makeTeamList(parent, pteam)
 	headp:DockMargin(0,0,0,4)
 	headp:Dock(TOP)
 	headp:SetTall(hs)
+
 	function headp:Paint(w, h)
 		surface.SetDrawColor(68, 68, 68, 255)
 		draw.RoundedBoxEx(4, 0, 0, w, h, Color(68, 68, 68, 120), true, true, false, false)
@@ -140,9 +133,11 @@ local function makeTeamList(parent, pteam)
 	surface.SetFont("RobotoHUD-20")
 	local tw, th = surface.GetTextSize("Join team")
 	but:SetWide(tw + 6)
+
 	function but:DoClick()
 		RunConsoleCommand("car_jointeam", pteam)
 	end
+
 	function but:Paint(w, h)
 		surface.SetDrawColor(team.GetColor(pteam))
 		surface.SetDrawColor(color_black)
@@ -159,34 +154,36 @@ local function makeTeamList(parent, pteam)
 			col.g = col.g * 1.2
 			col.b = col.b * 1.2
 		end
+
 		draw.ShadowText("Join team", "RobotoHUD-20", 2, h / 2 - th / 2, col, 0)
 	end
 
 	mlist = vgui.Create("DScrollPanel", pnl)
 	mlist:Dock(FILL)
-	function mlist:Paint(w, h)
 
+	function mlist:Paint(w, h)
 	end
 
 	-- child positioning
 	local canvas = mlist:GetCanvas()
 	canvas:DockPadding(8, 8, 8, 8)
-	function canvas:OnChildAdded( child )
-		child:Dock( TOP )
-		child:DockMargin( 0,0,0,4 )
+
+	function canvas:OnChildAdded(child)
+		child:Dock(TOP)
+		child:DockMargin(0,0,0,4)
 	end
 
 	local head = vgui.Create("DPanel")
 	head:SetTall(draw.GetFontHeight("RobotoHUD-15") * 1.05)
 	head.perm = true
 	local col = Color(190, 190, 190)
+
 	function head:Paint(w, h)
 		draw.ShadowText("Name", "RobotoHUD-15", 4, 0, col, 0)
-
 		draw.ShadowText("Ping", "RobotoHUD-15", w - 4, 0, col, 2)
 	end
-	mlist:AddItem(head)
 
+	mlist:AddItem(head)
 	return pnl
 end
 
@@ -215,6 +212,7 @@ function GM:ScoreboardShow()
 		menu:ShowCloseButton(false)
 		menu:SetTitle("")
 		menu:DockPadding(8, 8, 8, 8)
+
 		function menu:PerformLayout()
 			if IsValid(menu.CopsList) then
 				menu.CopsList:SetWidth((self:GetWide() - 16) * 0.5)
@@ -229,12 +227,12 @@ function GM:ScoreboardShow()
 		menu.Credits = vgui.Create("DPanel", menu)
 		menu.Credits:Dock(TOP)
 		menu.Credits:DockMargin(0, 0, 0, 4)
+
 		function menu.Credits:Paint(w, h)
 			surface.SetFont("RobotoHUD-25")
 			local t = GAMEMODE.Name || ""
 			local tw = surface.GetTextSize(t)
 			draw.ShadowText(t, "RobotoHUD-25", 4, 0, Color(199, 49, 29), 0)
-
 			draw.ShadowText(tostring(GAMEMODE.Version || "error") .. ", maintained by Zikaeroh, code by many cool people :)", "RobotoHUD-L12", 4 + tw + 24, h  * 0.9, Color(220, 220, 220), 0, 4)
 		end
 
@@ -261,6 +259,7 @@ function GM:ScoreboardShow()
 					c = ply:Nick()
 				end
 			end
+
 			if c then
 				draw.ShadowText(c, "RobotoHUD-10", tw + 8 + 4, h / 2, color_white, 0, 1)
 			end
@@ -270,8 +269,8 @@ function GM:ScoreboardShow()
 		but:Dock(LEFT)
 		but:SetText("")
 		but:DockMargin(0, 0, 4, 0)
-
 		but:SetWide(tw + 8)
+
 		function but:Paint(w, h)
 			local col = Color(90, 90, 90, 160)
 			local colt = Color(190, 190, 190)
@@ -282,15 +281,16 @@ function GM:ScoreboardShow()
 			end
 
 			draw.RoundedBox(4, 0, 0, w, h, col)
-
 			draw.ShadowText("Spectate", "RobotoHUD-15", w / 2, h / 2, colt, 1, 1)
 		end
+
 		function but:DoClick()
 			RunConsoleCommand("car_jointeam", TEAM_SPEC)
 		end
 
 		local main = vgui.Create("DPanel", menu)
 		main:Dock(FILL)
+
 		function main:Paint(w, h)
 			surface.SetDrawColor(40,40,40,230)
 		end
@@ -300,15 +300,15 @@ function GM:ScoreboardShow()
 		menu.CopsList:DockMargin(0, 0, 8, 0)
 		menu.RobbersList = makeTeamList(main, TEAM_PROP)
 		menu.RobbersList:Dock(FILL)
-
-
 	end
 end
+
 function GM:ScoreboardHide()
 	if GAMEMODE.GameState == ROUND_POST then
 		menu:Close()
 		return
 	end
+
 	if IsValid(menu) then
 		menu:Close()
 	end
@@ -327,8 +327,10 @@ function GM:DoScoreboardActionPopup(ply)
 		if ply:IsMuted() then
 			t = "Unmute"
 		end
-		local mute = actions:AddOption( t )
+
+		local mute = actions:AddOption(t)
 		mute:SetIcon("icon16/sound_mute.png")
+
 		function mute:DoClick()
 			if IsValid(ply) then
 				ply:SetMuted(!ply:IsMuted())

--- a/gamemodes/husklesph/gamemode/cl_scoreboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_scoreboard.lua
@@ -67,7 +67,7 @@ end
 local function doPlayerItems(self, mlist, pteam)
 	for k, ply in pairs(team.GetPlayers(pteam)) do
 		local found = false
-		for t,v in pairs(mlist:GetCanvas():GetChildren()) do
+		for t, v in pairs(mlist:GetCanvas():GetChildren()) do
 			if v.player == ply then
 				found = true
 				v.ctime = CurTime()
@@ -80,7 +80,7 @@ local function doPlayerItems(self, mlist, pteam)
 	end
 
 	local del = false
-	for t,v in pairs(mlist:GetCanvas():GetChildren()) do
+	for t, v in pairs(mlist:GetCanvas():GetChildren()) do
 		if !v.perm && v.ctime != CurTime() then
 			v:Remove()
 			del = true
@@ -117,7 +117,7 @@ local function makeTeamList(parent, pteam)
 	end
 
 	local headp = vgui.Create("DPanel", pnl)
-	headp:DockMargin(0,0,0,4)
+	headp:DockMargin(0, 0, 0, 4)
 	headp:Dock(TOP)
 	headp:SetTall(hs)
 
@@ -144,12 +144,12 @@ local function makeTeamList(parent, pteam)
 
 		local col = table.Copy(team.GetColor(pteam))
 		if self:IsDown() then
-			surface.SetDrawColor(12,50,50,120)
+			surface.SetDrawColor(12, 50, 50, 120)
 			col.r = col.r * 0.8
 			col.g = col.g * 0.8
 			col.b = col.b * 0.8
 		elseif self:IsHovered() then
-			surface.SetDrawColor(255,255,255,30)
+			surface.SetDrawColor(255, 255, 255, 30)
 			col.r = col.r * 1.2
 			col.g = col.g * 1.2
 			col.b = col.b * 1.2
@@ -170,7 +170,7 @@ local function makeTeamList(parent, pteam)
 
 	function canvas:OnChildAdded(child)
 		child:Dock(TOP)
-		child:DockMargin(0,0,0,4)
+		child:DockMargin(0, 0, 0, 4)
 	end
 
 	local head = vgui.Create("DPanel")
@@ -220,7 +220,7 @@ function GM:ScoreboardShow()
 		end
 
 		function menu:Paint(w, h)
-			surface.SetDrawColor(40,40,40,230)
+			surface.SetDrawColor(40, 40, 40, 230)
 			surface.DrawRect(0, 0, w, h)
 		end
 
@@ -292,7 +292,7 @@ function GM:ScoreboardShow()
 		main:Dock(FILL)
 
 		function main:Paint(w, h)
-			surface.SetDrawColor(40,40,40,230)
+			surface.SetDrawColor(40, 40, 40, 230)
 		end
 
 		menu.CopsList = makeTeamList(main, TEAM_HUNTER)

--- a/gamemodes/husklesph/gamemode/cl_spectate.lua
+++ b/gamemodes/husklesph/gamemode/cl_spectate.lua
@@ -1,4 +1,3 @@
-
 net.Receive("spectating_status", function(length)
 	GAMEMODE.SpectateMode = net.ReadInt(8)
 	GAMEMODE.Spectating = false

--- a/gamemodes/husklesph/gamemode/cl_taunt.lua
+++ b/gamemodes/husklesph/gamemode/cl_taunt.lua
@@ -139,8 +139,6 @@ local function openTauntMenu()
 	function menu:Paint(w, h)
 		surface.SetDrawColor(40,40,40,230)
 		surface.DrawRect(0, 0, w, h)
-
-		-- draw.ShadowText("Taunts", "RobotoHUD-15", 8, 4, color_white, 0)
 		surface.SetFont("RobotoHUD-25")
 		local t = "Taunts"
 		local tw,th = surface.GetTextSize(t)
@@ -184,12 +182,8 @@ local function openTauntMenu()
 	menu.CatList = clist
 	clist:Dock(FILL)
 	clist:DockMargin(0, 0, 0, 0)
-	-- local df = draw.GetFontHeight("RobotoHUD-15") * 1.6
-	function clist:Paint(w, h)
-		-- surface.SetDrawColor(60, 60, 60)
-		-- surface.DrawRect(0, 0, w, df)
 
-		-- draw.SimpleText("Categories", "RobotoHUD-15", w / 2, df / 2, color_white, 1, 1)
+	function clist:Paint(w, h)
 	end
 
 	local canvas = clist:GetCanvas()

--- a/gamemodes/husklesph/gamemode/cl_taunt.lua
+++ b/gamemodes/husklesph/gamemode/cl_taunt.lua
@@ -1,4 +1,3 @@
-
 include("sh_taunt.lua")
 
 local menu
@@ -32,6 +31,7 @@ local function fillList(mlist, taunts, cat)
 			v.Selected = true
 		end
 	end
+
 	mlist:Clear()
 	for k, t in pairs(taunts) do
 		if !TauntAllowedForPlayer(LocalPlayer(), t) then continue end
@@ -39,6 +39,7 @@ local function fillList(mlist, taunts, cat)
 		local but = vgui.Create("DButton")
 		but:SetTall(draw.GetFontHeight("RobotoHUD-L15") * 1.0)
 		but:SetText("")
+
 		function but:Paint(w, h)
 			local col = Color(255, 255, 255)
 			if self:IsDown() then
@@ -49,11 +50,13 @@ local function fillList(mlist, taunts, cat)
 			draw.ShadowText(t.name, "RobotoHUD-L15", 0, h / 2, col, 0, 1)
 			draw.ShadowText(math.Round(t.soundDuration * 10) / 10 .. "s", "RobotoHUD-L10", w, h / 2, col, 2, 1)
 		end
+
 		function but:DoClick()
 			RunConsoleCommand("ph_taunt", t.sound[math.random(#t.sound)])
 			saveCursor()
 			menu:Close()
 		end
+
 		mlist:AddItem(but)
 	end
 end
@@ -67,6 +70,7 @@ local function addCat(clist, name, taunts, mlist)
 	but:SetText("")
 	but.Selected = false
 	but.CatName = name
+
 	function but:Paint(w, h)
 		local col = Color(68, 68, 68, 160)
 		local colt = Color(190, 190, 190)
@@ -82,13 +86,14 @@ local function addCat(clist, name, taunts, mlist)
 		end
 
 		draw.RoundedBoxEx(4, 0, 0, w, h, col, true, false, true, false)
-
 		draw.ShadowText(dname, "RobotoHUD-15", w / 2, h / 2, colt, 1, 1)
 	end
+
 	function but:DoClick()
 		fillList(mlist, taunts, name)
 		self.Selected = true
 	end
+
 	clist:AddItem(but)
 	return but
 end
@@ -103,20 +108,20 @@ local function fillCats(clist, mlist)
 
 			c = c + 1
 		end
+
 		if c > 0 then
 			addCat(clist, k, taunts, mlist)
 		end
 	end
+
 	all.Selected = true
 end
 
 local function openTauntMenu()
 	restoreCursor()
-
 	if IsValid(menu) then
 		fillCats(menu.CatList, menu.TauntList)
 		fillList(menu.TauntList, menu.CurrentTaunts, menu.CurrentTauntCat)
-
 		if menu:IsVisible() then
 			saveCursor()
 		end
@@ -143,7 +148,6 @@ local function openTauntMenu()
 		local t = "Taunts"
 		local tw,th = surface.GetTextSize(t)
 		draw.ShadowText(t, "RobotoHUD-25", 8, 2, Color(49, 142, 219), 0)
-
 		draw.ShadowText(TauntMenuPhrase, "RobotoHUD-L15", 8 + tw + 16, 2 + th * 0.90, Color(220, 220, 220), 0, 4)
 	end
 
@@ -159,6 +163,7 @@ local function openTauntMenu()
 	but:DockMargin(0, 4, 4, 0)
 	but:SetTall(draw.GetFontHeight("RobotoHUD-15") * 1.3)
 	but:SetText("")
+
 	function but:Paint(w, h)
 		local col = Color(68, 68, 68, 160)
 		local colt = Color(190, 190, 190)
@@ -169,9 +174,9 @@ local function openTauntMenu()
 		end
 
 		draw.RoundedBoxEx(4, 0, 0, w, h, col, true, true, true, true)
-
 		draw.ShadowText("Random", "RobotoHUD-15", w / 2, h / 2, colt, 1, 1)
 	end
+
 	function but:DoClick()
 		RunConsoleCommand("ph_taunt_random")
 		saveCursor()
@@ -188,20 +193,19 @@ local function openTauntMenu()
 
 	local canvas = clist:GetCanvas()
 	canvas:DockPadding(0, 0, 0, 0)
-	function canvas:OnChildAdded( child )
-		child:Dock( TOP )
+
+	function canvas:OnChildAdded(child)
+		child:Dock(TOP)
 		child:DockMargin(0, 0, 0, 4)
 	end
-
-
 
 	local mlist = vgui.Create("DScrollPanel", menu)
 	menu.TauntList = mlist
 	mlist:Dock(FILL)
+
 	function mlist:Paint(w, h)
 		surface.SetDrawColor(68, 68, 68, 160)
 		surface.DrawOutlinedRect(0, 0, w, h)
-
 		surface.SetDrawColor(55, 55, 55, 120)
 		surface.DrawRect(1, 1, w - 2, h - 2)
 	end
@@ -209,8 +213,9 @@ local function openTauntMenu()
 	-- child positioning
 	local canvas = mlist:GetCanvas()
 	canvas:DockPadding(8, 8, 8, 8)
-	function canvas:OnChildAdded( child )
-		child:Dock( TOP )
+
+	function canvas:OnChildAdded(child)
+		child:Dock(TOP)
 		child:DockMargin(0, 0, 0, 4)
 	end
 
@@ -223,6 +228,7 @@ net.Receive("open_taunt_menu", openTauntMenu)
 
 net.Receive("ph_set_taunt_menu_phrase", function()
 	value_new = net.ReadString()
+
 	-- Prevent this from being done more than once. GMod is weird.
 	if TauntMenuPhrase == value_new then return end
 	TauntMenuPhrase = value_new

--- a/gamemodes/husklesph/gamemode/cl_taunt.lua
+++ b/gamemodes/husklesph/gamemode/cl_taunt.lua
@@ -142,11 +142,11 @@ local function openTauntMenu()
 	menu:DockPadding(8, 8 + draw.GetFontHeight("RobotoHUD-25"), 8, 8)
 
 	function menu:Paint(w, h)
-		surface.SetDrawColor(40,40,40,230)
+		surface.SetDrawColor(40, 40, 40, 230)
 		surface.DrawRect(0, 0, w, h)
 		surface.SetFont("RobotoHUD-25")
 		local t = "Taunts"
-		local tw,th = surface.GetTextSize(t)
+		local tw, th = surface.GetTextSize(t)
 		draw.ShadowText(t, "RobotoHUD-25", 8, 2, Color(49, 142, 219), 0)
 		draw.ShadowText(TauntMenuPhrase, "RobotoHUD-L15", 8 + tw + 16, 2 + th * 0.90, Color(220, 220, 220), 0, 4)
 	end

--- a/gamemodes/husklesph/gamemode/cl_voicepanels.lua
+++ b/gamemodes/husklesph/gamemode/cl_voicepanels.lua
@@ -20,7 +20,7 @@ function PANEL:Setup(ply)
 end
 
 function PANEL:Paint(w, h)
-	if (!IsValid(self.ply)) then return end
+	if !IsValid(self.ply) then return end
 
 	local volume = self.ply:VoiceVolume()
 	col = team.GetColor(self.ply:Team())
@@ -40,14 +40,14 @@ function PANEL:Paint(w, h)
 end
 
 function PANEL:Think()
-	if (self.fadeAnim) then
+	if self.fadeAnim then
 		self.fadeAnim:Run()
 	end
 end
 
 function PANEL:FadeOut(anim, delta, data)
-	if (anim.Finished) then
-		if (IsValid(PlayerVoicePanels[self.ply])) then
+	if anim.Finished then
+		if IsValid(PlayerVoicePanels[self.ply]) then
 			PlayerVoicePanels[self.ply]:Remove()
 			PlayerVoicePanels[self.ply] = nil
 			return
@@ -62,13 +62,13 @@ end
 derma.DefineControl("VoiceNotify", "", PANEL, "DPanel")
 
 function GM:PlayerStartVoice(ply)
-	if (!IsValid(g_VoicePanelList)) then return end
+	if !IsValid(g_VoicePanelList) then return end
 
 	-- There'd be an exta one if voice_loopback is on, so remove it.
 	GAMEMODE:PlayerEndVoice(ply)
 
-	if (IsValid(PlayerVoicePanels[ply])) then
-		if (PlayerVoicePanels[ply].fadeAnim) then
+	if IsValid(PlayerVoicePanels[ply]) then
+		if PlayerVoicePanels[ply].fadeAnim then
 			PlayerVoicePanels[ply].fadeAnim:Stop()
 			PlayerVoicePanels[ply].fadeAnim = nil
 		end
@@ -77,7 +77,7 @@ function GM:PlayerStartVoice(ply)
 		return
 	end
 
-	if (!IsValid(ply)) then return end
+	if !IsValid(ply) then return end
 
 	local pnl = g_VoicePanelList:Add("VoiceNotify")
 	pnl:Setup(ply)
@@ -86,7 +86,7 @@ end
 
 local function VoiceClean()
 	for k, v in pairs(PlayerVoicePanels) do
-		if (!IsValid(k) || !k:IsPlayer()) then
+		if !IsValid(k) || !k:IsPlayer() then
 			GAMEMODE:PlayerEndVoice(k)
 		end
 	end
@@ -94,8 +94,8 @@ end
 timer.Create("VoiceClean", 10, 0, VoiceClean)
 
 function GM:PlayerEndVoice(ply)
-	if (IsValid(PlayerVoicePanels[ply])) then
-		if (PlayerVoicePanels[ply].fadeAnim) then return end
+	if IsValid(PlayerVoicePanels[ply]) then
+		if PlayerVoicePanels[ply].fadeAnim then return end
 
 		PlayerVoicePanels[ply].fadeAnim = Derma_Anim("FadeOut", PlayerVoicePanels[ply], PlayerVoicePanels[ply].FadeOut)
 		PlayerVoicePanels[ply].fadeAnim:Start(2)

--- a/gamemodes/husklesph/gamemode/cl_voicepanels.lua
+++ b/gamemodes/husklesph/gamemode/cl_voicepanels.lua
@@ -19,7 +19,6 @@ end
 function PANEL:Setup( ply )
 
 	self.ply = ply
-	-- self.LabelName:SetText( ply:Nick() )
 	self.Avatar:SetPlayer( ply )
 
 	self.Color = team.GetColor( ply:Team() )
@@ -32,7 +31,6 @@ function PANEL:Paint( w, h )
 
 	if ( !IsValid( self.ply ) ) then return end
 
-	-- local volume = (math.sin(CurTime()) / 2 + 0.5)
 	local volume = self.ply:VoiceVolume()
 
 	col = team.GetColor(self.ply:Team())

--- a/gamemodes/husklesph/gamemode/cl_voicepanels.lua
+++ b/gamemodes/husklesph/gamemode/cl_voicepanels.lua
@@ -3,7 +3,7 @@ local PlayerVoicePanels = {}
 
 function PANEL:Init()
 	self.Avatar = vgui.Create("AvatarImage", self)
-	self.Avatar:Dock(LEFT);
+	self.Avatar:Dock(LEFT)
 	self.Avatar:SetSize(32, 32)
 	self.Color = color_transparent
 	self:SetSize(250, 32 + 8)
@@ -74,7 +74,7 @@ function GM:PlayerStartVoice(ply)
 		end
 
 		PlayerVoicePanels[ply]:SetAlpha(255)
-		return;
+		return
 	end
 
 	if (!IsValid(ply)) then return end

--- a/gamemodes/husklesph/gamemode/cl_voicepanels.lua
+++ b/gamemodes/husklesph/gamemode/cl_voicepanels.lua
@@ -2,153 +2,113 @@ local PANEL = {}
 local PlayerVoicePanels = {}
 
 function PANEL:Init()
-
-	self.Avatar = vgui.Create( "AvatarImage", self )
-	self.Avatar:Dock( LEFT );
-	self.Avatar:SetSize( 32, 32 )
-
+	self.Avatar = vgui.Create("AvatarImage", self)
+	self.Avatar:Dock(LEFT);
+	self.Avatar:SetSize(32, 32)
 	self.Color = color_transparent
-
-	self:SetSize( 250, 32 + 8 )
-	self:DockPadding( 4, 4, 4, 4 )
-	self:DockMargin( 2, 2, 2, 2 )
-	self:Dock( BOTTOM )
-
+	self:SetSize(250, 32 + 8)
+	self:DockPadding(4, 4, 4, 4)
+	self:DockMargin(2, 2, 2, 2)
+	self:Dock(BOTTOM)
 end
 
-function PANEL:Setup( ply )
-
+function PANEL:Setup(ply)
 	self.ply = ply
-	self.Avatar:SetPlayer( ply )
-
-	self.Color = team.GetColor( ply:Team() )
-
+	self.Avatar:SetPlayer(ply)
+	self.Color = team.GetColor(ply:Team())
 	self:InvalidateLayout()
-
 end
 
-function PANEL:Paint( w, h )
-
-	if ( !IsValid( self.ply ) ) then return end
+function PANEL:Paint(w, h)
+	if (!IsValid(self.ply)) then return end
 
 	local volume = self.ply:VoiceVolume()
-
 	col = team.GetColor(self.ply:Team())
 
 	surface.SetDrawColor(0, 0, 0, 255)
 	surface.DrawRect(0, 0, w, h)
 	surface.SetDrawColor(col.r, col.g, col.b, 120)
 	surface.DrawRect(0, 0, w, h)
-
 	surface.SetDrawColor(0, 0, 0, 255)
 	surface.DrawOutlinedRect(0, 0, w, h)
-
 	surface.SetDrawColor(col.r, col.g, col.b, 120)
 	surface.DrawRect(0, 0, math.floor(w * volume), h)
 	surface.SetDrawColor(0, 0, 0, 255)
 	surface.DrawOutlinedRect(0, 0, w * volume, h)
 
 	draw.ShadowText(self.ply:Nick(), "GModNotify", 4 + 32 + 4, h / 2, color_white, 0, 1)
-
 end
 
-function PANEL:Think( )
-
-	if ( self.fadeAnim ) then
+function PANEL:Think()
+	if (self.fadeAnim) then
 		self.fadeAnim:Run()
 	end
-
 end
 
-function PANEL:FadeOut( anim, delta, data )
-
-	if ( anim.Finished ) then
-
-		if ( IsValid( PlayerVoicePanels[ self.ply ] ) ) then
-			PlayerVoicePanels[ self.ply ]:Remove()
-			PlayerVoicePanels[ self.ply ] = nil
+function PANEL:FadeOut(anim, delta, data)
+	if (anim.Finished) then
+		if (IsValid(PlayerVoicePanels[self.ply])) then
+			PlayerVoicePanels[self.ply]:Remove()
+			PlayerVoicePanels[self.ply] = nil
 			return
 		end
 
-	return end
+		return
+	end
 
-	self:SetAlpha( 255 - (255 * delta) )
-
+	self:SetAlpha(255 - (255 * delta))
 end
 
-derma.DefineControl( "VoiceNotify", "", PANEL, "DPanel" )
+derma.DefineControl("VoiceNotify", "", PANEL, "DPanel")
 
-
-
-function GM:PlayerStartVoice( ply )
-
-	if ( !IsValid( g_VoicePanelList ) ) then return end
+function GM:PlayerStartVoice(ply)
+	if (!IsValid(g_VoicePanelList)) then return end
 
 	-- There'd be an exta one if voice_loopback is on, so remove it.
-	GAMEMODE:PlayerEndVoice( ply )
+	GAMEMODE:PlayerEndVoice(ply)
 
-
-	if ( IsValid( PlayerVoicePanels[ ply ] ) ) then
-
-		if ( PlayerVoicePanels[ ply ].fadeAnim ) then
-			PlayerVoicePanels[ ply ].fadeAnim:Stop()
-			PlayerVoicePanels[ ply ].fadeAnim = nil
+	if (IsValid(PlayerVoicePanels[ply])) then
+		if (PlayerVoicePanels[ply].fadeAnim) then
+			PlayerVoicePanels[ply].fadeAnim:Stop()
+			PlayerVoicePanels[ply].fadeAnim = nil
 		end
 
-		PlayerVoicePanels[ ply ]:SetAlpha( 255 )
-
+		PlayerVoicePanels[ply]:SetAlpha(255)
 		return;
-
 	end
 
-	if ( !IsValid( ply ) ) then return end
+	if (!IsValid(ply)) then return end
 
-	local pnl = g_VoicePanelList:Add( "VoiceNotify" )
-	pnl:Setup( ply )
-
-	PlayerVoicePanels[ ply ] = pnl
-
+	local pnl = g_VoicePanelList:Add("VoiceNotify")
+	pnl:Setup(ply)
+	PlayerVoicePanels[ply] = pnl
 end
-
 
 local function VoiceClean()
-
-	for k, v in pairs( PlayerVoicePanels ) do
-
-		if ( !IsValid( k ) || !k:IsPlayer() ) then
-			GAMEMODE:PlayerEndVoice( k )
+	for k, v in pairs(PlayerVoicePanels) do
+		if (!IsValid(k) || !k:IsPlayer()) then
+			GAMEMODE:PlayerEndVoice(k)
 		end
-
 	end
-
 end
+timer.Create("VoiceClean", 10, 0, VoiceClean)
 
-timer.Create( "VoiceClean", 10, 0, VoiceClean )
+function GM:PlayerEndVoice(ply)
+	if (IsValid(PlayerVoicePanels[ply])) then
+		if (PlayerVoicePanels[ply].fadeAnim) then return end
 
-
-function GM:PlayerEndVoice( ply )
-
-	if ( IsValid( PlayerVoicePanels[ ply ] ) ) then
-
-		if ( PlayerVoicePanels[ ply ].fadeAnim ) then return end
-
-		PlayerVoicePanels[ ply ].fadeAnim = Derma_Anim( "FadeOut", PlayerVoicePanels[ ply ], PlayerVoicePanels[ ply ].FadeOut )
-		PlayerVoicePanels[ ply ].fadeAnim:Start( 2 )
-
+		PlayerVoicePanels[ply].fadeAnim = Derma_Anim("FadeOut", PlayerVoicePanels[ply], PlayerVoicePanels[ply].FadeOut)
+		PlayerVoicePanels[ply].fadeAnim:Start(2)
 	end
-
 end
-
 
 local function CreateVoiceVGUI()
-
-	g_VoicePanelList = vgui.Create( "DPanel" )
-
+	g_VoicePanelList = vgui.Create("DPanel")
 	g_VoicePanelList:ParentToHUD()
-	g_VoicePanelList:SetPos( ScrW() - 300, 100 )
-	g_VoicePanelList:SetSize( 250, ScrH() - 200 )
-	g_VoicePanelList:SetPaintBackground( false )
+	g_VoicePanelList:SetPos(ScrW() - 300, 100)
+	g_VoicePanelList:SetSize(250, ScrH() - 200)
+	g_VoicePanelList:SetPaintBackground(false)
 
 end
 
-hook.Add( "InitPostEntity", "CreateVoiceVGUI", CreateVoiceVGUI )
+hook.Add("InitPostEntity", "CreateVoiceVGUI", CreateVoiceVGUI)

--- a/gamemodes/husklesph/gamemode/cl_wraptext.lua
+++ b/gamemodes/husklesph/gamemode/cl_wraptext.lua
@@ -39,8 +39,6 @@ function Builder:Run()
 				end
 				firstChunk = false
 				local spaces, rest = chunk:match("^([%s]*)(.*)$")
-				-- print(#spaces, "<" .. rest)
-
 				local sw = surface.GetTextSize(spaces)
 				self.curText = self.curText .. spaces
 				self.curWidth = self.curWidth + sw

--- a/gamemodes/husklesph/gamemode/cl_wraptext.lua
+++ b/gamemodes/husklesph/gamemode/cl_wraptext.lua
@@ -1,7 +1,6 @@
-
-
 local Builder = {}
 Builder.__index = Builder
+
 function Builder:WriteBlock(newLine)
 	local block = {}
 	block.text = self.curText
@@ -37,24 +36,21 @@ function Builder:Run()
 				if !firstChunk then
 					self:WriteBlock(true)
 				end
+
 				firstChunk = false
 				local spaces, rest = chunk:match("^([%s]*)(.*)$")
 				local sw = surface.GetTextSize(spaces)
 				self.curText = self.curText .. spaces
 				self.curWidth = self.curWidth + sw
-
 				for word in rest:gmatch("([^%s]+[%s]*)") do
 					local w = surface.GetTextSize(word)
 
 					-- can't we fit the word on the same line
 					if w + self.curWidth > self.maxWidth then
-
 						-- is the word too long for a single line (then we need to split it)
 						if w > self.maxWidth then
-
 							-- while our current word cannot fit in the line
 							while self.curWidth + w > self.maxWidth do
-
 								-- find the number of chracters that can fit
 								local chars = 1
 								while true do
@@ -63,10 +59,12 @@ function Builder:Run()
 										print("error" .. chars)
 										break
 									end
+
 									if aw + self.curWidth > self.maxWidth then
 										chars = chars - 1
 										break
 									end
+
 									chars = chars + 1
 								end
 
@@ -100,6 +98,7 @@ function Builder:Run()
 			end -- end chunk loop
 		end
 	end
+
 	self:WriteBlock(true)
 	local h = 0
 	for k, line in pairs(self.blocks) do
@@ -107,6 +106,7 @@ function Builder:Run()
 			h = h + draw.GetFontHeight(self.font)
 		end
 	end
+
 	self.height = h
 end
 

--- a/gamemodes/husklesph/gamemode/init.lua
+++ b/gamemodes/husklesph/gamemode/init.lua
@@ -5,7 +5,7 @@ local rootFolder = (GM || GAMEMODE).Folder:sub(11) .. "/gamemode/"
 -- add cs lua all the cl_ and sh_ files
 local files = file.Find(rootFolder .. "*", "LUA")
 for k, v in pairs(files) do
-	if v:sub(1,3) == "cl_" || v:sub(1,3) == "sh_" then
+	if v:sub(1, 3) == "cl_" || v:sub(1, 3) == "sh_" then
 		AddCSLuaFile(rootFolder .. v)
 	end
 end
@@ -73,7 +73,7 @@ end
 function GM:InitPostEntityAndMapCleanup()
 	for k, ent in pairs(ents.GetAll()) do
 		if ent:GetClass():find("door") then
-			ent:Fire("unlock","",0)
+			ent:Fire("unlock", "", 0)
 		end
 	end
 end

--- a/gamemodes/husklesph/gamemode/init.lua
+++ b/gamemodes/husklesph/gamemode/init.lua
@@ -109,10 +109,6 @@ function GM:EntityTakeDamage( ent, dmginfo )
 					local tdmg = DamageInfo()
 					tdmg:SetDamage(math.min(dmginfo:GetDamage(), math.max(self.HunterDamagePenalty:GetInt(), 1) ))
 					tdmg:SetDamageType(DMG_AIRBOAT)
-
-					-- tdmg:SetAttacker(ent)
-					-- tdmg:SetInflictor(ent)
-
 					tdmg:SetDamageForce(Vector(0, 0, 0))
 					att:TakeDamageInfo(tdmg)
 

--- a/gamemodes/husklesph/gamemode/init.lua
+++ b/gamemodes/husklesph/gamemode/init.lua
@@ -34,15 +34,15 @@ include("sv_bannedmodels.lua")
 include("sv_version.lua")
 
 -- NOTE: Make sure to sync default changes over to ULX.
-GM.VoiceHearTeam = CreateConVar("ph_voice_hearotherteam", 0, bit.bor(FCVAR_NOTIFY), "Can we hear the voices of opposing teams" )
-GM.VoiceHearDead = CreateConVar("ph_voice_heardead", 1, bit.bor(FCVAR_NOTIFY), "Can we hear the voices of dead players and spectators" )
-GM.RoundLimit = CreateConVar("ph_roundlimit", 10, bit.bor(FCVAR_NOTIFY), "Number of rounds before mapvote" )
-GM.HunterDamagePenalty = CreateConVar("ph_hunter_dmgpenalty", 3, bit.bor(FCVAR_NOTIFY), "Amount of damage a hunter should take for shooting an incorrect prop" )
-GM.HunterGrenadeAmount = CreateConVar("ph_hunter_smggrenades", 1, bit.bor(FCVAR_NOTIFY), "Amount of SMG grenades hunters should spawn with" )
-GM.DeadSpectateRoam = CreateConVar("ph_dead_canroam", 0, bit.bor(FCVAR_NOTIFY), "Can dead players use the roam spectate mode" )
-GM.PropsWinStayProps = CreateConVar("ph_props_onwinstayprops", 0, bit.bor(FCVAR_NOTIFY), "If the props win, they stay on the props team" )
-GM.PropsSmallSize = CreateConVar("ph_props_small_size", 200, bit.bor(FCVAR_NOTIFY), "Size that speed penalty for small size starts to apply (0 to disable)" )
-GM.PropsJumpPower = CreateConVar("ph_props_jumppower", 1.2, bit.bor(FCVAR_NOTIFY), "Jump power bonus for when props are disguised" )
+GM.VoiceHearTeam = CreateConVar("ph_voice_hearotherteam", 0, bit.bor(FCVAR_NOTIFY), "Can we hear the voices of opposing teams")
+GM.VoiceHearDead = CreateConVar("ph_voice_heardead", 1, bit.bor(FCVAR_NOTIFY), "Can we hear the voices of dead players and spectators")
+GM.RoundLimit = CreateConVar("ph_roundlimit", 10, bit.bor(FCVAR_NOTIFY), "Number of rounds before mapvote")
+GM.HunterDamagePenalty = CreateConVar("ph_hunter_dmgpenalty", 3, bit.bor(FCVAR_NOTIFY), "Amount of damage a hunter should take for shooting an incorrect prop")
+GM.HunterGrenadeAmount = CreateConVar("ph_hunter_smggrenades", 1, bit.bor(FCVAR_NOTIFY), "Amount of SMG grenades hunters should spawn with")
+GM.DeadSpectateRoam = CreateConVar("ph_dead_canroam", 0, bit.bor(FCVAR_NOTIFY), "Can dead players use the roam spectate mode")
+GM.PropsWinStayProps = CreateConVar("ph_props_onwinstayprops", 0, bit.bor(FCVAR_NOTIFY), "If the props win, they stay on the props team")
+GM.PropsSmallSize = CreateConVar("ph_props_small_size", 200, bit.bor(FCVAR_NOTIFY), "Size that speed penalty for small size starts to apply (0 to disable)")
+GM.PropsJumpPower = CreateConVar("ph_props_jumppower", 1.2, bit.bor(FCVAR_NOTIFY), "Jump power bonus for when props are disguised")
 GM.PropsCamDistance = CreateConVar("ph_props_camdistance", 1, bit.bor(FCVAR_NOTIFY), "The camera distance multiplier for props when disguised")
 GM.TauntMenuPhrase = CreateConVar("ph_taunt_menu_phrase", TauntMenuPhrase, bit.bor(FCVAR_NOTIFY), "Phrase shown at the top of the taunt menu")
 GM.MapTimeLimit = CreateConVar("ph_map_time_limit", -1, bit.bor(FCVAR_NOTIFY), "Minutes before declaring the next round to be the last round (-1 to disable)")
@@ -57,7 +57,6 @@ resource.AddFile("materials/melonbomber/skull_license.txt")
 
 function GM:Initialize()
 	self.RoundWaitForPlayers = CurTime()
-
 	self.DeathRagdolls = {}
 	self:LoadMapList()
 	self:LoadBannedModels()
@@ -84,12 +83,12 @@ function GM:Think()
 	self:SpectateThink()
 end
 
-function GM:PlayerNoClip( ply )
+function GM:PlayerNoClip(ply)
 	timer.Simple(0, function() ply:CalculateSpeed() end)
 	return ply:IsSuperAdmin() || ply:GetMoveType() == MOVETYPE_NOCLIP
 end
 
-function GM:EntityTakeDamage( ent, dmginfo )
+function GM:EntityTakeDamage(ent, dmginfo)
 	if IsValid(ent) then
 		if ent:IsPlayer() then
 			if IsValid(dmginfo:GetAttacker()) then
@@ -101,13 +100,13 @@ function GM:EntityTakeDamage( ent, dmginfo )
 				end
 			end
 		end
+
 		if ent:IsDisguisableAs() then
 			local att = dmginfo:GetAttacker()
 			if IsValid(att) && att:IsPlayer() && att:IsHunter() then
-
 				if bit.band(dmginfo:GetDamageType(), DMG_CRUSH) != DMG_CRUSH then
 					local tdmg = DamageInfo()
-					tdmg:SetDamage(math.min(dmginfo:GetDamage(), math.max(self.HunterDamagePenalty:GetInt(), 1) ))
+					tdmg:SetDamage(math.min(dmginfo:GetDamage(), math.max(self.HunterDamagePenalty:GetInt(), 1)))
 					tdmg:SetDamageType(DMG_AIRBOAT)
 					tdmg:SetDamageForce(Vector(0, 0, 0))
 					att:TakeDamageInfo(tdmg)

--- a/gamemodes/husklesph/gamemode/sh_disguise.lua
+++ b/gamemodes/husklesph/gamemode/sh_disguise.lua
@@ -101,8 +101,6 @@ function PlayerMeta:CalculateRotatedDisguiseMinsMaxs()
 	checkCorner(nmins, nmaxs, Vector(mins.x, mins.y), ang)
 	checkCorner(nmins, nmaxs, Vector(mins.x, maxs.y), ang)
 
-	-- print(mins, maxs, nmins, nmaxs)
-
 	return nmins, nmaxs
 end
 

--- a/gamemodes/husklesph/gamemode/sh_disguise.lua
+++ b/gamemodes/husklesph/gamemode/sh_disguise.lua
@@ -34,6 +34,7 @@ function PlayerMeta:CanFitHull(hullx, hully, hullz)
 	if tr.Hit then
 		return false
 	end
+
 	return true
 end
 
@@ -47,9 +48,9 @@ function PlayerMeta:GetPropEyePos()
 	if !self:IsDisguised() then
 		return self:GetShootPos()
 	end
+
 	local maxs = self:GetNWVector("disguiseMaxs")
 	local mins = self:GetNWVector("disguiseMins")
-
 	local reach = (maxs.z - mins.z) + 10
 	local trace = {}
 	trace.start = self:GetPos() + Vector(0, 0, 1.5)
@@ -72,6 +73,7 @@ function PlayerMeta:GetPropEyeTrace()
 		trace.mask = MASK_SHOT
 		return util.TraceLine(trace)
 	end
+
 	local trace = {}
 	trace.start = self:GetPropEyePos()
 	trace.endpos = trace.start + self:GetAimVector() * 100000
@@ -136,5 +138,6 @@ function GM:PlayerCanDisguiseCurrentTarget(ply)
 			end
 		end
 	end
+
 	return false, nil
 end

--- a/gamemodes/husklesph/gamemode/sh_taunt.lua
+++ b/gamemodes/husklesph/gamemode/sh_taunt.lua
@@ -49,10 +49,10 @@ end
 function TauntAllowedForPlayer(ply, tauntTable)
 	if tauntTable.sex then
 		if GAMEMODE && GAMEMODE.PlayerModelSex then
-			if tauntTable.sex ~= GAMEMODE.PlayerModelSex then
+			if tauntTable.sex != GAMEMODE.PlayerModelSex then
 				return false
 			end
-		elseif tauntTable.sex ~= ply.ModelSex then
+		elseif tauntTable.sex != ply.ModelSex then
 			return false
 		end
 	end
@@ -61,7 +61,7 @@ function TauntAllowedForPlayer(ply, tauntTable)
 		if !table.HasValue(tauntTable.team, ply:Team()) then
 			return false
 		end
-	elseif tauntTable.team ~= ply:Team() then
+	elseif tauntTable.team != ply:Team() then
 		return false
 	end
 
@@ -70,8 +70,8 @@ end
 
 -- display name, table of sound files, team (name or id), sex (nil for both), table of category ids, [duration in seconds]
 local function addTaunt(name, snd, pteam, sex, cats, duration, allowedModels)
-	if !name || type(name) ~= "string" then return end
-	if type(snd) ~= "table" then snd = {tostring(snd)} end
+	if !name || type(name) != "string" then return end
+	if type(snd) != "table" then snd = {tostring(snd)} end
 	if #snd == 0 then error("No sounds for " .. name) return end
 
 	local t = {}

--- a/gamemodes/husklesph/gamemode/sh_taunt.lua
+++ b/gamemodes/husklesph/gamemode/sh_taunt.lua
@@ -1,5 +1,3 @@
-
-
 Taunts = {}
 TauntCategories = {}
 AllowedTauntSounds = {}
@@ -16,9 +14,7 @@ function PlayerModelTauntAllowed(ply, whitelist)
 
 	local mod = ply:GetModel()
 	mod = player_manager.TranslateToPlayerModelName(mod)
-
 	local models = player_manager.AllValidModels()
-
 	for _, v in pairs(whitelist) do
 		if !models[v] then
 			-- v was not a name, so check it as a path
@@ -88,12 +84,14 @@ local function addTaunt(name, snd, pteam, sex, cats, duration, allowedModels)
 	else
 		t.team = tonumber(pteam)
 	end
+
 	if sex && #sex > 0 then
 		t.sex = sex
 		if sex == "both" || sex == "nil" then
 			t.sex = nil
 		end
 	end
+
 	t.name = name
 	t.allowedModels = allowedModels
 
@@ -151,6 +149,7 @@ local function loadTaunts(rootFolder)
 		if !f then
 			return
 		end
+
 		setfenv(f, tempG)
 		local b, err = pcall(f)
 

--- a/gamemodes/husklesph/gamemode/shared.lua
+++ b/gamemodes/husklesph/gamemode/shared.lua
@@ -9,30 +9,25 @@ GM.Email 	= "N/A"
 GM.Website 	= "N/A"
 GM.Version  = tab["version"] || "unknown"
 
-
 ROUND_WAIT = 1
 ROUND_HIDE = 2
 ROUND_SEEK = 3
 ROUND_POST = 4
 ROUND_MAPVOTE = 5
 
-
 TEAM_SPEC = 1
 TEAM_HUNTER = 2
 TEAM_PROP = 3
-
 
 WIN_NONE = TEAM_SPEC
 WIN_HUNTER = TEAM_HUNTER
 WIN_PROP = TEAM_PROP
 
-
 function PlayerMeta:IsSpectator() return self:Team() == TEAM_SPEC end
 function PlayerMeta:IsHunter() return self:Team() == TEAM_HUNTER end
 function PlayerMeta:IsProp() return self:Team() == TEAM_PROP end
 
-
-GM.StartWaitTime = CreateConVar("ph_mapstartwait", 30, bit.bor(FCVAR_NOTIFY, FCVAR_REPLICATED), "Number of seconds to wait for players on map start before starting round" )
+GM.StartWaitTime = CreateConVar("ph_mapstartwait", 30, bit.bor(FCVAR_NOTIFY, FCVAR_REPLICATED), "Number of seconds to wait for players on map start before starting round")
 
 team.SetUp(TEAM_SPEC, "Spectators", Color(120, 120, 120))
 team.SetUp(TEAM_HUNTER, "Hunters", Color(255, 150, 50))

--- a/gamemodes/husklesph/gamemode/sv_awards.lua
+++ b/gamemodes/husklesph/gamemode/sv_awards.lua
@@ -1,6 +1,5 @@
 PlayerAwards = {}
 
-
 PlayerAwards.LastPropStanding = {
 	name = "Longest Survivor",
 	desc = "Prop who survived longest",
@@ -12,7 +11,6 @@ PlayerAwards.LastPropStanding = {
 		return nil
 	end
 }
-
 
 PlayerAwards.LeastMovement = {
 	name = "Least Movement",
@@ -31,7 +29,6 @@ PlayerAwards.LeastMovement = {
 		return minPly
 	end
 }
-
 
 PlayerAwards.MostTaunts = {
 	name = "Most Taunts",
@@ -52,7 +49,6 @@ PlayerAwards.MostTaunts = {
 	end
 }
 
-
 PlayerAwards.FirstHunterKill = {
 	name = "First Blood",
 	desc = "Hunter who had the first kill",
@@ -60,7 +56,6 @@ PlayerAwards.FirstHunterKill = {
 		return GAMEMODE.FirstHunterKill
 	end
 }
-
 
 PlayerAwards.MostKills = {
 	name = "Most Kills",
@@ -81,7 +76,6 @@ PlayerAwards.MostKills = {
 	end
 }
 
-
 PlayerAwards.PropDamage = {
 	name = "Angriest Player",
 	desc = "Hunter who shot at props the most",
@@ -100,7 +94,6 @@ PlayerAwards.PropDamage = {
 		return nil
 	end
 }
-
 
 PlayerAwards.MostMovement = {
 	name = "Most Movement",

--- a/gamemodes/husklesph/gamemode/sv_bannedmodels.lua
+++ b/gamemodes/husklesph/gamemode/sv_bannedmodels.lua
@@ -1,19 +1,15 @@
 -- This file is what controls what models are banned. Models that are banned
 -- cannot be chosen as a disguise.
 
-
 GM.BannedModels = {} -- This is used as a hash table where the key is the model string and the value is true.
-
 
 util.AddNetworkString("ph_bannedmodels_getall")
 util.AddNetworkString("ph_bannedmodels_add")
 util.AddNetworkString("ph_bannedmodels_remove")
 
-
 function GM:IsModelBanned(model)
 	return self.BannedModels[model] == true
 end
-
 
 function GM:AddBannedModel(model)
 	if self.BannedModels[model] == true then return end
@@ -22,14 +18,12 @@ function GM:AddBannedModel(model)
 	self:SaveBannedModels()
 end
 
-
 function GM:RemoveBannedModel(model)
 	if self.BannedModels[model] != true then return end
 
 	self.BannedModels[model] = nil
 	self:SaveBannedModels()
 end
-
 
 function GM:SaveBannedModels()
 	-- ensure the folders are there
@@ -43,9 +37,9 @@ function GM:SaveBannedModels()
 			txt = txt .. key .. "\r\n"
 		end
 	end
+
 	file.Write("husklesph/bannedmodels.txt", txt)
 end
-
 
 function GM:LoadBannedModels()
 	local bannedModels = file.Read("husklesph/bannedmodels.txt", "DATA")
@@ -55,7 +49,6 @@ function GM:LoadBannedModels()
 		end
 	end
 end
-
 
 net.Receive("ph_bannedmodels_getall", function(len, ply)
 	net.Start("ph_bannedmodels_getall")
@@ -70,7 +63,6 @@ net.Receive("ph_bannedmodels_getall", function(len, ply)
 	net.Send(ply)
 end)
 
-
 net.Receive("ph_bannedmodels_add", function(len, ply)
 	if !ply:IsAdmin() then return end
 
@@ -82,7 +74,6 @@ net.Receive("ph_bannedmodels_add", function(len, ply)
 	net.WriteString(model)
 	net.Broadcast()
 end)
-
 
 net.Receive("ph_bannedmodels_remove", function(len, ply)
 	if !ply:IsAdmin() then return end

--- a/gamemodes/husklesph/gamemode/sv_bannedmodels.lua
+++ b/gamemodes/husklesph/gamemode/sv_bannedmodels.lua
@@ -27,7 +27,7 @@ end
 
 function GM:SaveBannedModels()
 	-- ensure the folders are there
-	if !file.Exists("husklesph/","DATA") then
+	if !file.Exists("husklesph/", "DATA") then
 		file.CreateDir("husklesph")
 	end
 

--- a/gamemodes/husklesph/gamemode/sv_bot.lua
+++ b/gamemodes/husklesph/gamemode/sv_bot.lua
@@ -1,5 +1,3 @@
-
-
 function GM:BotMove(ply, cmd)
 	cmd:SetViewAngles(Angle(0, 0, 0))
 	cmd:SetForwardMove(0)

--- a/gamemodes/husklesph/gamemode/sv_chatmsg.lua
+++ b/gamemodes/husklesph/gamemode/sv_chatmsg.lua
@@ -2,10 +2,8 @@
 -- the server. This is used instead of PrintMessage because we want to have
 -- colored messages (PrintMessage can't do this).
 
-
 util.AddNetworkString("ph_chatmsg")
 local PlayerMeta = FindMetaTable("Player")
-
 
 -- Sends a message to an individual player.
 function PlayerMeta:PlayerChatMsg(...)
@@ -13,7 +11,6 @@ function PlayerMeta:PlayerChatMsg(...)
 	net.WriteTable({...})
 	net.Send(self)
 end
-
 
 -- Sends a message to every player.
 function GlobalChatMsg(...)

--- a/gamemodes/husklesph/gamemode/sv_disguise.lua
+++ b/gamemodes/husklesph/gamemode/sv_disguise.lua
@@ -8,12 +8,12 @@ function GM:PlayerDisguise(ply)
 		if ply.LastDisguise && ply.LastDisguise + 1 > CurTime() then
 			return
 		end
+
 		ply:DisguiseAsProp(target)
 	end
 end
 
 function PlayerMeta:DisguiseAsProp(ent)
-
 	local hullxy, hullz = ent:GetPropSize()
 	if !self:CanFitHull(hullxy, hullxy, hullz) then
 		self:PlayerChatMsg(Color(255, 50, 50), "Not enough room to change")
@@ -23,8 +23,8 @@ function PlayerMeta:DisguiseAsProp(ent)
 	if !self:IsDisguised() then
 		self.OldPlayerModel = self:GetModel()
 	end
-	self:Flashlight(false)
 
+	self:Flashlight(false)
 
 	-- create an entity for the disguise
 	-- we can't use a clientside entity as it needs a shadow
@@ -51,7 +51,6 @@ function PlayerMeta:DisguiseAsProp(ent)
 	self:DrawShadow(false)
 	GAMEMODE:PlayerSetNewHull(self, hullxy, hullz, hullz)
 
-
 	local maxHealth = 1
 	local volume = 1
 	local phys = ent:GetPhysicsObject()
@@ -59,6 +58,7 @@ function PlayerMeta:DisguiseAsProp(ent)
 		maxHealth = math.Clamp(math.Round(phys:GetVolume() / 230), 1, 200)
 		volume = phys:GetVolume()
 	end
+
 	self.PercentageHealth = math.min(self:Health() / self:GetHMaxHealth(), self.PercentageHealth || 1)
 	local per = math.Clamp(self.PercentageHealth * maxHealth, 1, 200)
 	self:SetHealth(per)
@@ -66,7 +66,6 @@ function PlayerMeta:DisguiseAsProp(ent)
 	self:SetNWFloat("disguiseVolume", volume)
 
 	self:CalculateSpeed()
-
 
 	local offset = Vector(0, 0, ent:OBBMaxs().z - self:OBBMins().z + 10)
 	self:SetViewOffset(offset)
@@ -91,6 +90,7 @@ function PlayerMeta:UnDisguise()
 	if IsValid(dent) then
 		dent:Remove()
 	end
+
 	self.PercentageHealth = nil
 	self:SetNWBool("disguised", false)
 	self:SetColor(Color(255, 255, 255, 255))
@@ -102,6 +102,7 @@ function PlayerMeta:UnDisguise()
 		self:SetModel(self.OldPlayerModel)
 		self.OldPlayerModel = nil
 	end
+
 	self:SetViewOffset(Vector(0, 0, 64))
 	self:SetViewOffsetDucked(Vector(0, 0, 28))
 
@@ -143,6 +144,7 @@ end
 concommand.Add("ph_lockrotation", function(ply, com, args)
 	if !IsValid(ply) then return end
 	if !ply:IsDisguised() then return end
+
 	if ply:DisguiseRotationLocked() then
 		ply:DisguiseUnlockRotation()
 	else

--- a/gamemodes/husklesph/gamemode/sv_disguise.lua
+++ b/gamemodes/husklesph/gamemode/sv_disguise.lua
@@ -34,7 +34,6 @@ function PlayerMeta:DisguiseAsProp(ent)
 		self:SetNWEntity("disguiseEntity", dent)
 		dent.PropOwner = self
 		dent:SetPos(self:GetPos())
-		-- dent:SetParent(self)
 		dent:Spawn()
 	end
 	dent:SetModel(ent:GetModel())

--- a/gamemodes/husklesph/gamemode/sv_health.lua
+++ b/gamemodes/husklesph/gamemode/sv_health.lua
@@ -1,4 +1,3 @@
-
 local PlayerMeta = FindMetaTable("Player")
 
 function PlayerMeta:SetHMaxHealth(amo)

--- a/gamemodes/husklesph/gamemode/sv_killfeed.lua
+++ b/gamemodes/husklesph/gamemode/sv_killfeed.lua
@@ -1,4 +1,3 @@
-
 util.AddNetworkString("kill_feed_add")
 
 function GM:AddKillFeed(ply, attacker, dmginfo)

--- a/gamemodes/husklesph/gamemode/sv_mapvote.lua
+++ b/gamemodes/husklesph/gamemode/sv_mapvote.lua
@@ -136,14 +136,6 @@ function GM:StartMapVote()
 		table.insert(maps, math.random(#maps) + 1, v)
 	end
 	self.MapList = maps
-
-	-- make bots vote for a map
-	-- for k, ply in pairs(player.GetAll()) do
-	-- 	if ply:IsBot() then
-	-- 		self.MapVotes[ply] = maps[math.random(#maps)]
-	-- 	end
-	-- end
-
 	self:SetGameState(ROUND_MAPVOTE)
 	self:NetworkMapVoteStart()
 end

--- a/gamemodes/husklesph/gamemode/sv_mapvote.lua
+++ b/gamemodes/husklesph/gamemode/sv_mapvote.lua
@@ -64,7 +64,7 @@ local defaultMapList = {
 
 function GM:SaveMapList()
 	-- ensure the folders are there
-	if !file.Exists("husklesph/","DATA") then
+	if !file.Exists("husklesph/", "DATA") then
 		file.CreateDir("husklesph")
 	end
 

--- a/gamemodes/husklesph/gamemode/sv_mapvote.lua
+++ b/gamemodes/husklesph/gamemode/sv_mapvote.lua
@@ -26,11 +26,14 @@ function GM:RotateMap()
 			index = k
 		end
 	end
+
 	if !index then index = 1 end
 	index = index + 1
+
 	if index > #self.MapList then
 		index = 1
 	end
+
 	local nextMap = self.MapList[index]
 	self:ChangeMapTo(nextMap)
 end
@@ -41,6 +44,7 @@ function GM:ChangeMapTo(map)
 		self:SetGameState(ROUND_WAIT)
 		return
 	end
+
 	print("[husklesph] Rotate changing map to " .. map)
 	GlobalChatMsg("Changing map to ", map)
 	hook.Call("OnChangeMap", GAMEMODE)
@@ -59,7 +63,6 @@ local defaultMapList = {
 }
 
 function GM:SaveMapList()
-
 	-- ensure the folders are there
 	if !file.Exists("husklesph/","DATA") then
 		file.CreateDir("husklesph")
@@ -69,6 +72,7 @@ function GM:SaveMapList()
 	for k, map in pairs(self.MapList) do
 		txt = txt .. map .. "\r\n"
 	end
+
 	file.Write("husklesph/maplist.txt", txt)
 end
 
@@ -79,6 +83,7 @@ function GM:LoadMapList()
 		for map in jason:gmatch("[^\r\n]+") do
 			table.insert(tbl, map)
 		end
+
 		self.MapList = tbl
 	else
 		local tbl = {}
@@ -98,6 +103,7 @@ function GM:LoadMapList()
 				end
 			end
 		end
+
 		self.MapList = tbl
 		self:SaveMapList()
 	end
@@ -135,6 +141,7 @@ function GM:StartMapVote()
 	for k, v in pairs(self.MapList) do
 		table.insert(maps, math.random(#maps) + 1, v)
 	end
+
 	self.MapList = maps
 	self:SetGameState(ROUND_MAPVOTE)
 	self:NetworkMapVoteStart()
@@ -187,7 +194,6 @@ function GM:NetworkMapVoteStart(ply)
 	end
 	net.WriteUInt(0, 16)
 
-
 	if ply then
 		net.Send(ply)
 	else
@@ -206,7 +212,6 @@ function GM:NetworkMapVotes(ply)
 		net.WriteString(map)
 	end
 	net.WriteUInt(0, 8)
-
 
 	if ply then
 		net.Send(ply)
@@ -228,6 +233,7 @@ concommand.Add("ph_votemap", function(ply, com, args)
 				break
 			end
 		end
+
 		if !found then
 			ply:ChatPrint("Invalid map " .. args[1])
 			return

--- a/gamemodes/husklesph/gamemode/sv_player.lua
+++ b/gamemodes/husklesph/gamemode/sv_player.lua
@@ -2,7 +2,6 @@ local PlayerMeta = FindMetaTable("Player")
 
 function GM:PlayerInitialSpawn(ply)
 	self:RoundsSetupPlayer(ply)
-
 	self:TeamsSetupPlayer(ply)
 
 	if self:GetGameState() != ROUND_WAIT then
@@ -36,15 +35,15 @@ function GM:PlayerDisconnected(ply)
 end
 
 util.AddNetworkString("hull_set")
-function GM:PlayerSpawn( ply )
 
+function GM:PlayerSpawn(ply)
 	ply:UnCSpectate()
 
-	player_manager.OnPlayerSpawn( ply )
-	player_manager.RunClass( ply, "Spawn" )
+	player_manager.OnPlayerSpawn(ply)
+	player_manager.RunClass(ply, "Spawn")
 
-	hook.Call( "PlayerLoadout", GAMEMODE, ply )
-	hook.Call( "PlayerSetModel", GAMEMODE, ply )
+	hook.Call("PlayerLoadout", GAMEMODE, ply)
+	hook.Call("PlayerSetModel", GAMEMODE, ply)
 
 	ply:UnDisguise()
 	ply:CalculateSpeed()
@@ -53,7 +52,6 @@ function GM:PlayerSpawn( ply )
 	ply:SetHealth(ply:GetHMaxHealth())
 
 	GAMEMODE:PlayerSetNewHull(ply)
-
 	self:PlayerSetupHands(ply)
 
 	local col = team.GetColor(ply:Team())
@@ -65,28 +63,28 @@ end
 
 function GM:PlayerSetupHands(ply)
 	local oldhands = ply:GetHands()
-	if ( IsValid( oldhands ) ) then oldhands:Remove() end
+	if (IsValid(oldhands)) then oldhands:Remove() end
 
-	local hands = ents.Create( "gmod_hands" )
-	if ( IsValid( hands ) ) then
-		ply:SetHands( hands )
-		hands:SetOwner( ply )
+	local hands = ents.Create("gmod_hands")
+	if (IsValid(hands)) then
+		ply:SetHands(hands)
+		hands:SetOwner(ply)
 
 		-- Which hands should we use?
-		local cl_playermodel = ply:GetInfo( "cl_playermodel" )
-		local info = player_manager.TranslatePlayerHands( cl_playermodel )
-		if ( info ) then
-			hands:SetModel( info.model )
-			hands:SetSkin( info.skin )
-			hands:SetBodyGroups( info.body )
+		local cl_playermodel = ply:GetInfo("cl_playermodel")
+		local info = player_manager.TranslatePlayerHands(cl_playermodel)
+		if (info) then
+			hands:SetModel(info.model)
+			hands:SetSkin(info.skin)
+			hands:SetBodyGroups(info.body)
 		end
 
 		-- Attach them to the viewmodel
-		local vm = ply:GetViewModel( 0 )
-		hands:AttachToViewmodel( vm )
+		local vm = ply:GetViewModel(0)
+		hands:AttachToViewmodel(vm)
 
-		vm:DeleteOnRemove( hands )
-		ply:DeleteOnRemove( hands )
+		vm:DeleteOnRemove(hands)
+		ply:DeleteOnRemove(hands)
 
 		hands:Spawn()
 	end
@@ -109,14 +107,15 @@ function PlayerMeta:CalculateSpeed()
 			local mul = math.Clamp(self:GetNWFloat("disguiseVolume", 1) / GAMEMODE.PropsSmallSize:GetFloat(), 0.5, 1)
 			settings.walkSpeed = settings.walkSpeed * mul
 		end
+
 		if settings.runSpeed > settings.walkSpeed then
 			settings.runSpeed = settings.walkSpeed
 		end
+
 		settings.jumpPower = settings.jumpPower * GAMEMODE.PropsJumpPower:GetFloat()
 	end
 
 	hook.Call("PlayerCalculateSpeed", ply, settings)
-
 
 	-- set out new speeds
 	if settings.canRun then
@@ -124,6 +123,7 @@ function PlayerMeta:CalculateSpeed()
 	else
 		self:SetRunSpeed(settings.walkSpeed || 1)
 	end
+
 	if self:GetMoveType() != MOVETYPE_NOCLIP then
 		if settings.canMove then
 			self:SetMoveType(MOVETYPE_WALK)
@@ -131,6 +131,7 @@ function PlayerMeta:CalculateSpeed()
 			self:SetMoveType(MOVETYPE_NONE)
 		end
 	end
+
 	self.CanRun = settings.canRun
 	self:SetWalkSpeed(settings.walkSpeed || 1)
 	self:SetJumpPower(settings.jumpPower || 1)
@@ -150,7 +151,6 @@ function GM:PlayerLoadout(ply)
 		end
 	end
 end
-
 
 local playerModels = {}
 local function addModel(model, sex)
@@ -180,17 +180,14 @@ addModel("refugee02", "male")
 addModel("refugee03", "male")
 addModel("refugee04", "male")
 
-
-function GM:PlayerSetModel( ply )
-
-	local cl_playermodel = ply:GetInfo( "cl_playermodel" )
-
+function GM:PlayerSetModel(ply)
+	local cl_playermodel = ply:GetInfo("cl_playermodel")
 	local playerModel = table.Random(playerModels)
 	cl_playermodel = playerModel.model
 
-	local modelname = player_manager.TranslatePlayerModel( cl_playermodel )
-	util.PrecacheModel( modelname )
-	ply:SetModel( modelname )
+	local modelname = player_manager.TranslatePlayerModel(cl_playermodel)
+	util.PrecacheModel(modelname)
+	ply:SetModel(modelname)
 	ply.ModelSex = playerModel.sex
 
 	net.Start("player_model_sex")
@@ -201,7 +198,6 @@ end
 function GM:PlayerDeathSound()
 	return true
 end
-
 
 -- This is only a shallow copy.
 local function mergeTables(...)
@@ -216,7 +212,6 @@ local function mergeTables(...)
 	return newTable
 end
 
-
 -------------------------------
 -------------------------------
 -------------------------------
@@ -227,12 +222,10 @@ end
 -- basically just killed players every time or got them stuck in each other so it
 -- was not very useful. The TTT code has been tweaked to work better with Prophunters.
 
-
 -- Nice Fisher-Yates implementation, from Wikipedia
 local rand = math.random
 local function shuffleTable(t)
 	local n = #t
-
 	while n > 2 do
 		-- n is now the last pertinent index
 		local k = rand(n) -- 1 <= k <= n
@@ -244,7 +237,6 @@ local function shuffleTable(t)
 	return t
 end
 
-
 function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)
 	if !IsValid(ply) || ply:IsSpectator() then return true end
 	if !rigged && (!IsValid(spwn) || !spwn:IsInWorld()) then return false end
@@ -252,16 +244,13 @@ function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)
 	-- spwn is normally an ent, but we sometimes use a vector for jury rigged
 	-- positions
 	local pos = rigged && spwn || spwn:GetPos()
-
 	if !util.IsInWorld(pos) then return false end
 
-	local blocking = ents.FindInBox(pos + Vector( -32, -32, 0 ), pos + Vector( 32, 32, 64 )) -- Changed from (-16, -16, 0) (16, 16, 64)
-
+	local blocking = ents.FindInBox(pos + Vector(-32, -32, 0), pos + Vector(32, 32, 64)) -- Changed from (-16, -16, 0) (16, 16, 64)
 	for _, blockingEnt in ipairs(blocking) do
 		if IsValid(blockingEnt) && blockingEnt:IsPlayer() && !blockingEnt:IsSpectator() && blockingEnt:Alive() then
 			if force then
 				blockingEnt:Kill()
-
 				blockingEnt:PlayerChatMsg(Color(200, 20, 20), "You were killed because there are not enough spawnpoints.")
 				for _, value in ipairs(player.GetAll()) do
 					if value:IsAdmin() || value:IsSuperAdmin() then
@@ -276,7 +265,6 @@ function GM:IsSpawnpointSuitable(ply, spwn, force, rigged)
 
 	return true
 end
-
 
 -- TTT only had a single table for spawnpoints but we're going to use three different ones
 -- so that we can try to group teams together.
@@ -293,7 +281,6 @@ local hunterSpawnTypes = {"info_player_counterterrorist",
 local spectatorSpawnTypes = {"info_player_start", "gmod_player_start",
 "info_player_teamspawn", "ins_spawnpoint", "aoc_spawnpoint",
 "dys_spawn_point", "info_player_coop", "info_player_deathmatch"}
-
 
 local function getSpawnEnts(plyTeam, force_all)
 	local tblToUse
@@ -327,32 +314,29 @@ local function getSpawnEnts(plyTeam, force_all)
 	end
 
 	shuffleTable(tbl)
-
 	return tbl
 end
-
 
 -- Generate points next to and above the spawn that we can test for suitability (a "3x3 grid")
 local function pointsAroundSpawn(spwn)
 	if !IsValid(spwn) then return {} end
-	local pos = spwn:GetPos()
 
+	local pos = spwn:GetPos()
 	local w, _ = 50, 72 -- Increased from the default 36, 72 as it seems to work better with Prophunters.
 
 	-- all rigged positions
 	-- could be done without typing them out, but would take about as much time
 	return {
-		pos + Vector( w,  0,  0),
-		pos + Vector( 0,  w,  0),
-		pos + Vector( w,  w,  0),
+		pos + Vector(w,  0,  0),
+		pos + Vector(0,  w,  0),
+		pos + Vector(w,  w,  0),
 		pos + Vector(-w,  0,  0),
-		pos + Vector( 0, -w,  0),
+		pos + Vector(0, -w,  0),
 		pos + Vector(-w, -w,  0),
 		pos + Vector(-w,  w,  0),
-		pos + Vector( w, -w,  0)
+		pos + Vector(w, -w,  0)
 	};
 end
-
 
 function GM:PlayerSelectSpawn(ply)
 	local plyTeam = ply:Team()
@@ -364,9 +348,7 @@ function GM:PlayerSelectSpawn(ply)
 
 	-- Should be true for each first player on a team
 	if !self.SpawnPoints[plyTeam] || (table.IsEmpty(self.SpawnPoints[plyTeam])) || (!IsTableOfEntitiesValid(self.SpawnPoints[plyTeam])) then
-
 		self.SpawnPoints[plyTeam] = getSpawnEnts(plyTeam, false)
-
 		-- One might think that we have to regenerate our spawnpoint
 		-- cache. Otherwise, any rigged spawn entities would not get reused, and
 		-- MORE new entities would be made instead. In reality, the map cleanup at
@@ -393,7 +375,6 @@ function GM:PlayerSelectSpawn(ply)
 
 	-- That did not work, so now look around spawns
 	local picked = nil
-
 	for _, spwn in pairs(self.SpawnPoints[plyTeam]) do
 		picked = spwn -- just to have something if all else fails
 
@@ -409,6 +390,7 @@ function GM:PlayerSelectSpawn(ply)
 				else
 					spawnType = "info_player_start"
 				end
+
 				local rigSpwn = ents.Create(spawnType)
 				if IsValid(rigSpwn) then
 					rigSpwn:SetPos(rig)
@@ -433,13 +415,11 @@ function GM:PlayerSelectSpawn(ply)
 	return picked
 end
 
-
 -- TTT code ends here.
 
 -----------------------------------
 -----------------------------------
 -----------------------------------
-
 
 function GM:PlayerDeathThink(ply)
 	if self:CanRespawn(ply) then
@@ -496,10 +476,9 @@ function GM:DoPlayerDeath(ply, attacker, dmginfo)
 		-- set the last death award
 		self.LastPropDeath = ply
 	end
+
 	ply:UnDisguise()
-
 	ply:Freeze(false) -- why?, *sigh*
-
 	ply:CreateRagdoll()
 
 	local ent = ply:GetNWEntity("DeathRagdoll")
@@ -517,7 +496,6 @@ function GM:DoPlayerDeath(ply, attacker, dmginfo)
 
 			-- did a hunter kill a prop
 			if attacker:IsHunter() && ply:IsProp() then
-
 				-- increase their round kills
 				attacker.HunterKills = (attacker.HunterKills || 0) + 1
 
@@ -532,14 +510,12 @@ function GM:DoPlayerDeath(ply, attacker, dmginfo)
 	self:AddKillFeed(ply, attacker, dmginfo)
 end
 
-function GM:PlayerDeath(ply, inflictor, attacker )
-
+function GM:PlayerDeath(ply, inflictor, attacker)
 	ply.NextSpawnTime = CurTime() + 1
 	ply.DeathTime = CurTime()
 
 	-- time until player can spectate another player
 	ply.SpectateTime = CurTime() + 2
-
 end
 
 function GM:KeyPress(ply, key)
@@ -554,14 +530,15 @@ function GM:PlayerSwitchFlashlight(ply)
 	if ply:IsDisguised() then
 		return false
 	end
+
 	return true
 end
 
-function GM:PlayerShouldTaunt( ply, actid )
+function GM:PlayerShouldTaunt(ply, actid)
 	return false
 end
 
-function GM:PlayerCanSeePlayersChat( text, teamOnly, listener, speaker )
+function GM:PlayerCanSeePlayersChat(text, teamOnly, listener, speaker)
 	if !IsValid(speaker) then return false end
 	local canhear = self:PlayerCanHearChatVoice(listener, speaker, "chat", teamOnly)
 	return canhear
@@ -576,15 +553,13 @@ function GM:StartCommand(ply, cmd)
 	end
 end
 
-
-local sv_alltalk = GetConVar( "sv_alltalk" )
-function GM:PlayerCanHearPlayersVoice( listener, talker )
+local sv_alltalk = GetConVar("sv_alltalk")
+function GM:PlayerCanHearPlayersVoice(listener, talker)
 	if !IsValid(talker) then return false end
 	return self:PlayerCanHearChatVoice(listener, talker, "voice")
 end
 
-
-function GM:PlayerCanHearChatVoice( listener, talker, typ, teamOnly )
+function GM:PlayerCanHearChatVoice(listener, talker, typ, teamOnly)
 	if typ == "chat" && teamOnly then
 		if listener:Team() != talker:Team() then
 			return false
@@ -610,7 +585,6 @@ function GM:PlayerCanHearChatVoice( listener, talker, typ, teamOnly )
 	end
 
 	return true
-
 end
 
 function GM:PlayerCanPickupWeapon(ply, wep)
@@ -619,5 +593,6 @@ function GM:PlayerCanPickupWeapon(ply, wep)
 			return false
 		end
 	end
+
 	return true
 end

--- a/gamemodes/husklesph/gamemode/sv_player.lua
+++ b/gamemodes/husklesph/gamemode/sv_player.lua
@@ -63,17 +63,17 @@ end
 
 function GM:PlayerSetupHands(ply)
 	local oldhands = ply:GetHands()
-	if (IsValid(oldhands)) then oldhands:Remove() end
+	if IsValid(oldhands) then oldhands:Remove() end
 
 	local hands = ents.Create("gmod_hands")
-	if (IsValid(hands)) then
+	if IsValid(hands) then
 		ply:SetHands(hands)
 		hands:SetOwner(ply)
 
 		-- Which hands should we use?
 		local cl_playermodel = ply:GetInfo("cl_playermodel")
 		local info = player_manager.TranslatePlayerHands(cl_playermodel)
-		if (info) then
+		if info then
 			hands:SetModel(info.model)
 			hands:SetSkin(info.skin)
 			hands:SetBodyGroups(info.body)
@@ -295,7 +295,7 @@ local function getSpawnEnts(plyTeam, force_all)
 	local tbl = {}
 	for _, classname in ipairs(tblToUse) do
 		for _, e in ipairs(ents.FindByClass(classname)) do
-			if IsValid(e) && (!e.BeingRemoved) then
+			if IsValid(e) && !e.BeingRemoved then
 				table.insert(tbl, e)
 			end
 		end
@@ -306,7 +306,7 @@ local function getSpawnEnts(plyTeam, force_all)
 		local allSpawnTypes = mergeTables(propSpawnTypes, hunterSpawnTypes, spectatorSpawnTypes)
 		for _, classname in ipairs(allSpawnTypes) do
 			for _, e in ipairs(ents.FindByClass(classname)) do
-				if IsValid(e) && (!e.BeingRemoved) then
+				if IsValid(e) && !e.BeingRemoved then
 					table.insert(tbl, e)
 				end
 			end
@@ -347,7 +347,7 @@ function GM:PlayerSelectSpawn(ply)
 	end
 
 	-- Should be true for each first player on a team
-	if !self.SpawnPoints[plyTeam] || (table.IsEmpty(self.SpawnPoints[plyTeam])) || (!IsTableOfEntitiesValid(self.SpawnPoints[plyTeam])) then
+	if !self.SpawnPoints[plyTeam] || table.IsEmpty(self.SpawnPoints[plyTeam]) || !IsTableOfEntitiesValid(self.SpawnPoints[plyTeam]) then
 		self.SpawnPoints[plyTeam] = getSpawnEnts(plyTeam, false)
 		-- One might think that we have to regenerate our spawnpoint
 		-- cache. Otherwise, any rigged spawn entities would not get reused, and

--- a/gamemodes/husklesph/gamemode/sv_player.lua
+++ b/gamemodes/husklesph/gamemode/sv_player.lua
@@ -335,7 +335,7 @@ local function pointsAroundSpawn(spwn)
 		pos + Vector(-w, -w,  0),
 		pos + Vector(-w,  w,  0),
 		pos + Vector(w, -w,  0)
-	};
+	}
 end
 
 function GM:PlayerSelectSpawn(ply)

--- a/gamemodes/husklesph/gamemode/sv_player.lua
+++ b/gamemodes/husklesph/gamemode/sv_player.lua
@@ -55,7 +55,7 @@ function GM:PlayerSpawn(ply)
 	self:PlayerSetupHands(ply)
 
 	local col = team.GetColor(ply:Team())
-	local vec = Vector(col.r / 255,col.g / 255,col.b / 255)
+	local vec = Vector(col.r / 255, col.g / 255, col.b / 255)
 	ply:SetPlayerColor(vec)
 
 	ply.LastSpawnTime = CurTime()

--- a/gamemodes/husklesph/gamemode/sv_ragdoll.lua
+++ b/gamemodes/husklesph/gamemode/sv_ragdoll.lua
@@ -28,18 +28,19 @@ dtypes[DMG_BLAST_SURFACE] = ""
 dtypes[DMG_DIRECT] = "Fire"
 dtypes[DMG_BUCKSHOT] = "Bullet"
 
-
 local DeathRagdollsPerPlayer = 3
 local DeathRagdollsPerServer = 22
 
 if !PlayerMeta.CreateRagdollOld then
 	PlayerMeta.CreateRagdollOld = PlayerMeta.CreateRagdoll
 end
+
 function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 	local ent = self:GetNWEntity("DeathRagdoll")
 
 	-- remove old player ragdolls
 	if !self.DeathRagdolls then self.DeathRagdolls = {} end
+
 	local countPlayerRagdolls = 1
 	for k,rag in pairs(self.DeathRagdolls) do
 		if IsValid(rag) then
@@ -48,6 +49,7 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 			self.DeathRagdolls[k] = nil
 		end
 	end
+
 	if DeathRagdollsPerPlayer >= 0 && countPlayerRagdolls > DeathRagdollsPerPlayer then
 		for i = 0,countPlayerRagdolls do
 			if countPlayerRagdolls > DeathRagdollsPerPlayer then
@@ -69,6 +71,7 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 			GAMEMODE.DeathRagdolls[k] = nil
 		end
 	end
+
 	if DeathRagdollsPerServer >= 0 && c2 > DeathRagdollsPerServer then
 		for i = 0,c2 do
 			if c2 > DeathRagdollsPerServer then
@@ -81,19 +84,20 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 		end
 	end
 
-	local Data = duplicator.CopyEntTable( self )
+	local Data = duplicator.CopyEntTable(self)
 	if !util.IsValidRagdoll(Data.Model) then
 		return
 	end
 
-	local ent = ents.Create( "prop_ragdoll" )
-	duplicator.DoGeneric( ent, Data )
+	local ent = ents.Create("prop_ragdoll")
+	duplicator.DoGeneric(ent, Data)
 	ent:Spawn()
 	ent:SetCollisionGroup(COLLISION_GROUP_WEAPON)
 	ent:Fire("kill","",60 * 8)
 	if ent.SetPlayerColor then
 		ent:SetPlayerColor(self:GetPlayerColor())
 	end
+
 	ent:SetNWEntity("RagdollOwner", self)
 
 	ent.Corpse = {}
@@ -113,24 +117,19 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 
 	-- set velocities
 	local Vel = self:GetVelocity()
-
 	local iNumPhysObjects = ent:GetPhysicsObjectCount()
 	for Bone = 0, iNumPhysObjects-1 do
-
-		local PhysObj = ent:GetPhysicsObjectNum( Bone )
+		local PhysObj = ent:GetPhysicsObjectNum(Bone)
 		if IsValid(PhysObj) then
-
-			local Pos, Ang = self:GetBonePosition( ent:TranslatePhysBoneToBone( Bone ) )
-			PhysObj:SetPos( Pos )
-			PhysObj:SetAngles( Ang )
-			PhysObj:AddVelocity( Vel )
-
+			local Pos, Ang = self:GetBonePosition(ent:TranslatePhysBoneToBone(Bone))
+			PhysObj:SetPos(Pos)
+			PhysObj:SetAngles(Ang)
+			PhysObj:AddVelocity(Vel)
 		end
-
 	end
 
 	-- finish up
-	self:SetNWEntity("DeathRagdoll", ent )
+	self:SetNWEntity("DeathRagdoll", ent)
 	table.insert(self.DeathRagdolls,ent)
 	table.insert(GAMEMODE.DeathRagdolls,ent)
 end
@@ -138,21 +137,25 @@ end
 if !PlayerMeta.GetRagdollEntityOld then
 	PlayerMeta.GetRagdollEntityOld = PlayerMeta.GetRagdollEntity
 end
+
 function PlayerMeta:GetRagdollEntity()
 	local ent = self:GetNWEntity("DeathRagdoll")
 	if IsValid(ent) then
 		return ent
 	end
+
 	return self:GetRagdollEntityOld()
 end
 
 if !PlayerMeta.GetRagdollOwnerOld then
 	PlayerMeta.GetRagdollOwnerOld = PlayerMeta.GetRagdollOwner
 end
+
 function EntityMeta:GetRagdollOwner()
 	local ent = self:GetNWEntity("RagdollOwner")
 	if IsValid(ent) then
 		return ent
 	end
+
 	return self:GetRagdollOwnerOld()
 end

--- a/gamemodes/husklesph/gamemode/sv_ragdoll.lua
+++ b/gamemodes/husklesph/gamemode/sv_ragdoll.lua
@@ -42,7 +42,7 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 	if !self.DeathRagdolls then self.DeathRagdolls = {} end
 
 	local countPlayerRagdolls = 1
-	for k,rag in pairs(self.DeathRagdolls) do
+	for k, rag in pairs(self.DeathRagdolls) do
 		if IsValid(rag) then
 			countPlayerRagdolls = countPlayerRagdolls + 1
 		else
@@ -51,10 +51,10 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 	end
 
 	if DeathRagdollsPerPlayer >= 0 && countPlayerRagdolls > DeathRagdollsPerPlayer then
-		for i = 0,countPlayerRagdolls do
+		for i = 0, countPlayerRagdolls do
 			if countPlayerRagdolls > DeathRagdollsPerPlayer then
 				self.DeathRagdolls[1]:Remove()
-				table.remove(self.DeathRagdolls,1)
+				table.remove(self.DeathRagdolls, 1)
 				countPlayerRagdolls = countPlayerRagdolls - 1
 			else
 				break
@@ -64,7 +64,7 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 
 	-- remove old server ragdolls
 	local c2 = 1
-	for k,rag in pairs(GAMEMODE.DeathRagdolls) do
+	for k, rag in pairs(GAMEMODE.DeathRagdolls) do
 		if IsValid(rag) then
 			c2 = c2 + 1
 		else
@@ -73,10 +73,10 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 	end
 
 	if DeathRagdollsPerServer >= 0 && c2 > DeathRagdollsPerServer then
-		for i = 0,c2 do
+		for i = 0, c2 do
 			if c2 > DeathRagdollsPerServer then
 				GAMEMODE.DeathRagdolls[1]:Remove()
-				table.remove(GAMEMODE.DeathRagdolls,1)
+				table.remove(GAMEMODE.DeathRagdolls, 1)
 				c2 = c2 - 1
 			else
 				break
@@ -93,7 +93,7 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 	duplicator.DoGeneric(ent, Data)
 	ent:Spawn()
 	ent:SetCollisionGroup(COLLISION_GROUP_WEAPON)
-	ent:Fire("kill","",60 * 8)
+	ent:Fire("kill", "", 60 * 8)
 	if ent.SetPlayerColor then
 		ent:SetPlayerColor(self:GetPlayerColor())
 	end
@@ -130,8 +130,8 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 
 	-- finish up
 	self:SetNWEntity("DeathRagdoll", ent)
-	table.insert(self.DeathRagdolls,ent)
-	table.insert(GAMEMODE.DeathRagdolls,ent)
+	table.insert(self.DeathRagdolls, ent)
+	table.insert(GAMEMODE.DeathRagdolls, ent)
 end
 
 if !PlayerMeta.GetRagdollEntityOld then

--- a/gamemodes/husklesph/gamemode/sv_realism.lua
+++ b/gamemodes/husklesph/gamemode/sv_realism.lua
@@ -1,7 +1,5 @@
-
 function GM:RealismThink()
 	for k, ply in pairs(player.GetAll()) do
-
 		if ply:Alive() then
 			-- don't increase velocity when jumping off ground
 			if ply:KeyPressed(IN_JUMP) && ply.PrevOnGround then
@@ -12,6 +10,7 @@ function GM:RealismThink()
 				newVel.z = curVel.z
 				ply:SetLocalVelocity(newVel)
 			end
+
 			ply.PrevSpeed = ply:GetVelocity()
 			ply.PrevOnGround = ply:OnGround()
 		end
@@ -19,7 +18,7 @@ function GM:RealismThink()
 end
 
 -- minimum velocity to trigger function is 530
-function GM:GetFallDamage( ply, vel )
+function GM:GetFallDamage(ply, vel)
 	if vel > 530 then
 		local minvel = vel - 530
 		local dmg = math.ceil(minvel / 278 * 50)

--- a/gamemodes/husklesph/gamemode/sv_respawn.lua
+++ b/gamemodes/husklesph/gamemode/sv_respawn.lua
@@ -1,5 +1,3 @@
-
-
 function GM:CanRespawn(ply)
 	if ply:IsSpectator() then
 		return false

--- a/gamemodes/husklesph/gamemode/sv_rounds.lua
+++ b/gamemodes/husklesph/gamemode/sv_rounds.lua
@@ -319,7 +319,7 @@ end
 
 local function ForceEndRound(ply, command, args)
 	-- ply is nil on dedicated server console
-	if (!IsValid(ply)) || ply:IsAdmin() || ply:IsSuperAdmin() || cvars.Bool("sv_cheats", 0) then
+	if !IsValid(ply) || ply:IsAdmin() || ply:IsSuperAdmin() || cvars.Bool("sv_cheats", 0) then
 		GAMEMODE.RoundSettings = GAMEMODE.RoundSettings || {}
 		GAMEMODE:EndRound(WIN_NONE)
 	else

--- a/gamemodes/husklesph/gamemode/sv_rounds.lua
+++ b/gamemodes/husklesph/gamemode/sv_rounds.lua
@@ -237,12 +237,6 @@ function GM:EndRound(reason)
 
 	self.RoundSettings.NextRoundTime = 15
 	self:NetworkGameSettings()
-
-	-- for k, ply in pairs(self:GetPlayingPlayers()) do
-	-- 	if ply:Team() == winningTeam then
-	-- 	else
-	-- 	end
-	-- end
 	self:SetGameState(ROUND_POST)
 end
 

--- a/gamemodes/husklesph/gamemode/sv_rounds.lua
+++ b/gamemodes/husklesph/gamemode/sv_rounds.lua
@@ -8,17 +8,14 @@ GM.GameState = GAMEMODE && GAMEMODE.GameState || ROUND_WAIT
 GM.StateStart = GAMEMODE && GAMEMODE.StateStart || CurTime()
 GM.Rounds = GAMEMODE && GAMEMODE.Rounds || 0
 
-
 local function mapTimeLimitTimerResult()
 	if GAMEMODE.Rounds < GAMEMODE.RoundLimit:GetInt() then -- Only change if we haven't already hit the round limit
 		GAMEMODE.Rounds = GAMEMODE.RoundLimit:GetInt() - 1 -- Allows for 1 extra round before hitting the limit
 	end
 end
 
-
 local function changeMapTimeLimitTimer(oldValueMinutes, newValueMinutes)
 	local timerName = "ph_timer_map_time_limit"
-
 	if newValueMinutes == -1 then -- Timer should be disabled
 		timer.Remove(timerName)
 	else
@@ -41,11 +38,9 @@ local function changeMapTimeLimitTimer(oldValueMinutes, newValueMinutes)
 	end
 end
 
-
 cvars.AddChangeCallback("ph_map_time_limit", function(convar, oldValue, newValue)
 	changeMapTimeLimitTimer(tonumber(oldValue), tonumber(newValue))
 end)
-
 
 function GM:GetGameState()
 	return self.GameState
@@ -66,6 +61,7 @@ function GM:GetPlayingPlayers()
 			table.insert(players, ply)
 		end
 	end
+
 	return players
 end
 
@@ -113,6 +109,7 @@ function GM:SetupRound()
 			c = c + 1
 		end
 	end
+
 	if c < 2 then
 		GlobalChatMsg("Not enough players to start round")
 		self:SetGameState(ROUND_WAIT)
@@ -145,8 +142,8 @@ function GM:SetupRound()
 			ply:SetNWBool("RoundInGame", false)
 		end
 	end
-	self:CleanupMap()
 
+	self:CleanupMap()
 	self.Rounds = self.Rounds + 1
 
 	if self.Rounds == self.RoundLimit:GetInt() then
@@ -158,7 +155,6 @@ function GM:SetupRound()
 end
 
 function GM:StartRound()
-
 	self.LastPropDeath = nil
 	self.FirstHunterKill = nil
 
@@ -187,12 +183,9 @@ function GM:StartRound()
 	self.RoundSettings.RoundTime = math.Round((c * 0.5 / hunters + 60 * 4)  * math.sqrt(props / hunters))
 	self.RoundSettings.PropsCamDistance = self.PropsCamDistance:GetFloat()
 	print("Round time is " .. (self.RoundSettings.RoundTime / 60) .. " (" .. c .. " props)")
-
 	self:NetworkGameSettings()
 	self:SetGameState(ROUND_SEEK)
-
 	GlobalChatMsg("Round has started")
-
 end
 
 function GM:EndRound(reason)
@@ -206,6 +199,7 @@ function GM:EndRound(reason)
 		GlobalChatMsg(team.GetColor(TEAM_PROP), team.GetName(TEAM_PROP), " win")
 		winningTeam = TEAM_PROP
 	end
+
 	self.LastRoundResult = reason
 
 	local awards = {}
@@ -266,6 +260,7 @@ function GM:CheckForVictory()
 			end
 		end
 	end
+
 	if red == 0 && blue == 0 then
 		self:EndRound(WIN_NONE)
 		return
@@ -275,6 +270,7 @@ function GM:CheckForVictory()
 		self:EndRound(WIN_PROP)
 		return
 	end
+
 	if blue == 0 then
 		self:EndRound(WIN_HUNTER)
 		return
@@ -289,6 +285,7 @@ function GM:RoundsThink()
 				c = c + 1
 			end
 		end
+
 		if c >= 2 && self.RoundWaitForPlayers + self.StartWaitTime:GetFloat() < CurTime() then
 			self:SetupRound()
 		end
@@ -298,7 +295,6 @@ function GM:RoundsThink()
 		end
 	elseif self:GetGameState() == ROUND_SEEK then
 		self:CheckForVictory()
-
 		for k, ply in pairs(self:GetPlayingPlayers()) do
 			if ply:IsProp() then
 				ply.PropMovement = (ply.PropMovement || 0) + ply:GetVelocity():Length()
@@ -312,6 +308,7 @@ function GM:RoundsThink()
 				if self.LastRoundResult != WIN_PROP || !self.PropsWinStayProps:GetBool() then
 					self:SwapTeams()
 				end
+
 				self:SetupRound()
 			end
 		end

--- a/gamemodes/husklesph/gamemode/sv_spectate.lua
+++ b/gamemodes/husklesph/gamemode/sv_spectate.lua
@@ -12,6 +12,7 @@ function PlayerMeta:CSpectate(mode, spectatee)
 		self:SpectateEntity(Entity(-1))
 		self.Spectatee = nil
 	end
+
 	self.SpectateMode = mode
 	self.Spectating = true
 	net.Start("spectating_status")
@@ -54,7 +55,6 @@ end
 
 function GM:SpectateNext(ply, direction)
 	direction = direction || 1
-
 	local players = {}
 	local index = 1
 	for k, v in pairs(player.GetAll()) do
@@ -68,11 +68,13 @@ function GM:SpectateNext(ply, direction)
 			end
 		end
 	end
+
 	if #players > 0 then
 		index = index + direction
 		if index > #players then
 			index = 1
 		end
+
 		if index < 1 then
 			index = #players
 		end
@@ -105,15 +107,12 @@ function GM:SpectateNext(ply, direction)
 end
 
 function GM:ChooseSpectatee(ply)
-
 	if !ply.SpectateTime || ply.SpectateTime < CurTime() then
-
 		if ply:KeyPressed(IN_JUMP) then
 			if ply:GetCSpectateMode() != OBS_MODE_ROAMING && (ply:IsSpectator() || self.DeadSpectateRoam:GetBool()) then
 				ply:CSpectate(OBS_MODE_ROAMING)
 			end
 		else
-
 			local direction
 			if ply:KeyPressed(IN_ATTACK) then
 				direction = 1

--- a/gamemodes/husklesph/gamemode/sv_taunt.lua
+++ b/gamemodes/husklesph/gamemode/sv_taunt.lua
@@ -124,7 +124,6 @@ function GM:AutoTauntCheck()
 			end
 
 			if !ply.TauntEnd || CurTime() > ply.AutoTauntDeadline then
-				-- ply:ChatPrint("I warned you!")
 				DoRandomTaunt(ply)
 				begin = ply.TauntEnd
 			end
@@ -135,7 +134,6 @@ function GM:AutoTauntCheck()
 
 		local delta = math.random(minDeadline, maxDeadline)
 		ply.AutoTauntDeadline = begin + delta
-		-- ply:ChatPrint("If you don't taunt within " .. tostring(delta) .. " seconds, the server will do it for you!")
 	end
 end
 

--- a/gamemodes/husklesph/gamemode/sv_teams.lua
+++ b/gamemodes/husklesph/gamemode/sv_teams.lua
@@ -1,5 +1,3 @@
-
-
 function GM:TeamsSetupPlayer(ply)
 	local cops = team.NumPlayers(TEAM_HUNTER)
 	local robbers = team.NumPlayers(TEAM_PROP)
@@ -14,15 +12,13 @@ concommand.Add("car_jointeam", function(ply, com, args)
 	local curteam = ply:Team()
 	local newteam = tonumber(args[1] || "") || 0
 	if newteam == TEAM_SPEC && curteam != TEAM_SPEC then
-
 		ply:SetTeam(newteam)
 		if ply:Alive() then
 			ply:Kill()
 		end
+
 		GlobalChatMsg(ply:Nick(), " changed team to ", team.GetColor(newteam), team.GetName(newteam))
-
 	elseif newteam >= TEAM_HUNTER && newteam <= TEAM_PROP && newteam != curteam then
-
 		-- make sure we can't join the bigger team
 		local otherteam = newteam == TEAM_HUNTER && TEAM_PROP || TEAM_HUNTER
 		if team.NumPlayers(newteam) <= team.NumPlayers(otherteam) then
@@ -30,19 +26,17 @@ concommand.Add("car_jointeam", function(ply, com, args)
 			if ply:Alive() then
 				ply:Kill()
 			end
+
 			GlobalChatMsg(ply:Nick(), " changed team to ", team.GetColor(newteam), team.GetName(newteam))
 		else
 			ply:PlayerChatMsg("Team full, you cannot join")
 		end
-
 	end
-
 end)
 
 function GM:CheckTeamBalance()
 	if !self.TeamBalanceCheck || self.TeamBalanceCheck < CurTime() then
 		self.TeamBalanceCheck = CurTime() + 3 * 60 -- check every 3 minutes
-
 		local diff = team.NumPlayers(TEAM_HUNTER) - team.NumPlayers(TEAM_PROP)
 		if diff < -1 || diff > 1 then -- teams must be off by more than 2 for team balance
 			self.TeamBalanceTimer = CurTime() + 30 -- balance in 30 seconds
@@ -51,6 +45,7 @@ function GM:CheckTeamBalance()
 			end
 		end
 	end
+
 	if self.TeamBalanceTimer && self.TeamBalanceTimer < CurTime() then
 		self.TeamBalanceTimer = nil
 		self:BalanceTeams()
@@ -65,6 +60,7 @@ function GM:BalanceTeams(nokill)
 			biggerTeam = TEAM_HUNTER
 			smallerTeam = TEAM_PROP
 		end
+
 		diff = team.NumPlayers(biggerTeam) - team.NumPlayers(smallerTeam)
 		while diff > 1 do
 			local players = team.GetPlayers(biggerTeam)
@@ -73,6 +69,7 @@ function GM:BalanceTeams(nokill)
 			if !nokill && ply:Alive() then
 				ply:Kill()
 			end
+
 			GlobalChatMsg(ply:Nick(), " team balanced to ", team.GetColor(smallerTeam), team.GetName(smallerTeam))
 			diff = diff - 2
 		end
@@ -87,5 +84,6 @@ function GM:SwapTeams()
 			ply:SetTeam(TEAM_HUNTER)
 		end
 	end
+
 	GlobalChatMsg(Color(50, 220, 150), "Teams have been swapped")
 end

--- a/gamemodes/husklesph/gamemode/sv_teams.lua
+++ b/gamemodes/husklesph/gamemode/sv_teams.lua
@@ -40,7 +40,7 @@ function GM:CheckTeamBalance()
 		local diff = team.NumPlayers(TEAM_HUNTER) - team.NumPlayers(TEAM_PROP)
 		if diff < -1 || diff > 1 then -- teams must be off by more than 2 for team balance
 			self.TeamBalanceTimer = CurTime() + 30 -- balance in 30 seconds
-			for k,ply in pairs(player.GetAll()) do
+			for k, ply in pairs(player.GetAll()) do
 				ply:ChatPrint("Auto team balance in 30 seconds")
 			end
 		end
@@ -55,7 +55,7 @@ end
 function GM:BalanceTeams(nokill)
 	local diff = team.NumPlayers(TEAM_HUNTER) - team.NumPlayers(TEAM_PROP)
 	if diff < -1 || diff > 1 then -- teams must be off by more than 2 for team balance
-		local biggerTeam, smallerTeam = TEAM_PROP,TEAM_HUNTER
+		local biggerTeam, smallerTeam = TEAM_PROP, TEAM_HUNTER
 		if diff > 0 then
 			biggerTeam = TEAM_HUNTER
 			smallerTeam = TEAM_PROP

--- a/gamemodes/husklesph/gamemode/sv_version.lua
+++ b/gamemodes/husklesph/gamemode/sv_version.lua
@@ -1,13 +1,13 @@
 local url = "https://raw.githubusercontent.com/zikaeroh/husklesph/master/gamemodes/husklesph/husklesph.txt"
 local downloadlinks = "https://steamcommunity.com/sharedfiles/filedetails/?id=1585255351"
 
-
 function GM:CheckForNewVersion(ply)
 	local req = {}
 	req.url = url
 	req.failed = function(reason)
 		print("Couldn't get version file.", reason)
 	end
+
 	req.success = function(code, body, headers)
 		local tab = util.KeyValuesToTable(body)
 		if !tab || !tab.version then
@@ -35,6 +35,7 @@ function GM:CheckForNewVersion(ply)
 			MsgC("\n")
 		end
 	end
+
 	HTTP(req)
 end
 
@@ -47,5 +48,6 @@ concommand.Add("ph_version", function(ply)
 	else
 		MsgC(color, msg, "\n") -- Print to the server console
 	end
+
 	GAMEMODE:CheckForNewVersion(ply)
 end)

--- a/gamemodes/husklesph/gamemode/taunts/default.lua
+++ b/gamemodes/husklesph/gamemode/taunts/default.lua
@@ -36,7 +36,6 @@ addTaunt("Over there", {
 	"vo/npc/male01/overthere02.wav"
 }, "props", "male", {"talk"})
 
-
 addTaunt("Ready when you are", {
 	"vo/npc/female01/readywhenyouare01.wav",
 	"vo/npc/female01/readywhenyouare02.wav"
@@ -54,7 +53,6 @@ addTaunt("Watch out", {
 addTaunt("Watch out", {
 	"vo/npc/female01/watchout.wav"
 }, "props", "female", {"talk"})
-
 
 addTaunt("Zombie Speak", {
 	"npc/zombie/zombie_voice_idle1.wav",

--- a/lua/ulx/modules/sh/husklesph.lua
+++ b/lua/ulx/modules/sh/husklesph.lua
@@ -85,7 +85,6 @@ commandToUlx("ph_taunt_menu_phrase", function(c)
     c:help("Set the taunt menu phrase.")
 end)
 
-
 commandToUlx("ph_auto_taunt", function(c)
     c:addParam{ type = ULib.cmds.BoolArg, hint = "enabled", ULib.cmds.optional }
     c:help("Enable/disable auto taunt.")
@@ -107,7 +106,6 @@ autoTauntDelay:defaultAccess(ULib.ACCESS_ADMIN)
 autoTauntDelay:addParam{ type = ULib.cmds.NumArg, default = 60, min = 5, max = 600, hint = "minimum", ULib.cmds.round, ULib.cmds.optional }
 autoTauntDelay:addParam{ type = ULib.cmds.NumArg, default = 120, min = 5, max = 600, hint = "minimum", ULib.cmds.round, ULib.cmds.optional }
 autoTauntDelay:help("Set the auto taunt delay range.")
-
 
 commandToUlx("ph_endround", function(c)
     c:help("Ends the round on a tie.")

--- a/lua/ulx/modules/sh/husklesph.lua
+++ b/lua/ulx/modules/sh/husklesph.lua
@@ -1,4 +1,4 @@
-if engine.ActiveGamemode() ~= "husklesph" then return end
+if engine.ActiveGamemode() != "husklesph" then return end
 
 local CATEGORY_NAME = "HusklesPH"
 


### PR DESCRIPTION
Various style fixes.
Code that was commented out has been removed. Almost all of it was debug code.
Removed spacing on the edges of argument/parameter lists. Newlines were adjusted to try and get rid of unnecessary gaps and also logically separate blocks of code.
The only change to functionality is converting instances of `~=` to `!=`.