### PR TITLE
Endround menu rework

### DIFF
--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -115,10 +115,7 @@ concommand.Add("ph_endroundmenu_close", function()
 end)
 
 function GM:OpenEndRoundMenu()
-	chat.Close()
-
 	if IsValid(menu) then
-		menu.ChatTextEntry:SetText("")
 		menu:SetVisible(true)
 		return
 	end
@@ -207,113 +204,6 @@ function GM:OpenEndRoundMenu()
 	function canvas:OnChildAdded(child)
 		child:Dock(TOP)
 		child:DockMargin(0, 0, 0, 1)
-	end
-
-	-- chat section
-	local pnl = vgui.Create("DPanel", leftpnl)
-	pnl:Dock(BOTTOM)
-	pnl:DockMargin(0, 20, 0, 0)
-
-	function pnl:PerformLayout()
-		self:SetTall(leftpnl:GetTall() * 0.5)
-	end
-
-	function pnl:Paint(w, h)
-		surface.SetDrawColor(20, 20, 20, 150)
-		local t = draw.GetFontHeight("RobotoHUD-25") + 2
-		surface.DrawRect(0, t, w, h - t)
-	end
-
-	local header = vgui.Create("DLabel", pnl)
-	header:Dock(TOP)
-	header:SetFont("RobotoHUD-25")
-	header:SetTall(draw.GetFontHeight("RobotoHUD-25"))
-	header:SetText("Chat")
-	header:DockMargin(4, 2, 4, 2)
-
-	local sayPnl = vgui.Create("DPanel", pnl)
-	sayPnl:Dock(BOTTOM)
-	sayPnl:DockPadding(4, 4, 4, 4)
-	sayPnl:SetTall(draw.GetFontHeight("RobotoHUD-15") + 8)
-
-	local entry = vgui.Create("DTextEntry", sayPnl)
-
-	function sayPnl:Paint(w, h)
-		if entry.Focused then
-			surface.SetDrawColor(30, 20, 20, 150)
-		else
-			surface.SetDrawColor(20, 20, 20, 150)
-		end
-		surface.DrawRect(0, 0, w, h)
-	end
-
-	local say = vgui.Create("DLabel", sayPnl)
-	say:Dock(LEFT)
-	say:SetFont("RobotoHUD-15")
-	say:SetTextColor(Color(150, 150, 150))
-	say:SetText("Say:")
-	say:DockMargin(4, 0, 0, 0)
-	say:SizeToContentsX()
-
-	entry:Dock(FILL)
-	menu.ChatTextEntry = entry
-	entry:SetFont("RobotoHUD-15")
-	entry:SetTextColor(color_white)
-
-	function entry:OnEnter(...)
-		RunConsoleCommand("say", self:GetValue())
-		self:SetText("")
-		timer.Simple(0, function()
-			menu:SetKeyboardInputEnabled(true)
-			self:RequestFocus()
-		end)
-	end
-
-	local colCursor = Color(255, 0, 0)
-	local colText = Color(180, 180, 180)
-
-	function entry:Paint(w, h)
-		self:DrawTextEntryText(self.Focused && color_white || colText, self.m_colHighlight, colCursor)
-	end
-
-	function entry:OnGetFocus()
-		self.Focused = true
-		menu:SetKeyboardInputEnabled(true)
-	end
-
-	function entry:OnLoseFocus()
-		self.Focused = false
-		menu:SetKeyboardInputEnabled(false)
-	end
-
-	local mlist = vgui.Create("DScrollPanel", pnl)
-	menu.ChatList = mlist
-	mlist:Dock(FILL)
-
-	function mlist:Paint(w, h)
-	end
-
-	-- child positioning
-	local canvas = mlist:GetCanvas()
-	canvas:DockPadding(0, 0, 0, 0)
-
-	function canvas:OnChildAdded(child)
-		child:Dock(TOP)
-		child:DockMargin(0, 0, 0, 1)
-	end
-
-	function mlist.VBar:SetUp(_barsize_, _canvassize_)
-		local oldSize = self.CanvasSize
-
-		self.BarSize = _barsize_
-		self.CanvasSize = math.max(_canvassize_ - _barsize_, 1)
-
-		self:SetEnabled(_canvassize_ > _barsize_)
-		self:InvalidateLayout()
-
-		if self:GetScroll() == oldSize || (oldSize == 1 && self:GetScroll() == 0) then
-			self:SetScroll(self.CanvasSize)
-		end
 	end
 
 	-- results section
@@ -438,7 +328,6 @@ function GM:EndRoundMenuResults(res)
 	menu.ResultsPanel:SetVisible(true)
 	menu.VotePanel:SetVisible(false)
 	menu.Results = res
-	menu.ChatList:Clear()
 	menu.ResultList:Clear()
 	if res.winningTeam == WIN_HUNTER || res.winningTeam == WIN_PROP then
 		menu.WinningTeam:SetText(team.GetName(res.winningTeam) .. " win!")
@@ -554,32 +443,6 @@ function GM:EndRoundMapVote()
 
 		menu.MapVoteList:AddItem(but)
 	end
-end
-
-function GM:EndRoundAddChatText(...)
-	if !IsValid(menu) then
-		return
-	end
-
-	local pnl = vgui.Create("DPanel")
-	pnl.Text = {...}
-
-	function pnl:PerformLayout()
-		if self.Text then
-			self.TextLines = WrapText("RobotoHUD-15", self:GetWide() - 16, self.Text)
-		end
-		if self.TextLines then
-			self:SetTall(self.TextLines.height)
-		end
-	end
-
-	function pnl:Paint(w, h)
-		if self.TextLines then
-			self.TextLines:Paint(4, draw.GetFontHeight("RobotoHUD-15") * -0.2)
-		end
-	end
-
-	menu.ChatList:AddItem(pnl)
 end
 
 function GM:CloseRoundMenu()

--- a/gamemodes/husklesph/gamemode/cl_endroundboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_endroundboard.lua
@@ -1,142 +1,19 @@
-if GAMEMODE && IsValid(GAMEMODE.EndRoundPanel) then
-	GAMEMODE.EndRoundPanel:Remove()
-end
-
 local menu
-local muted = Material("icon32/muted.png")
-local unmuted = Material("icon32/unmuted.png")
 
-local function addPlayerItem(self, mlist, ply)
-	local but = vgui.Create("DButton")
-	but.player = ply
-	but.ctime = CurTime()
-	but:SetTall(draw.GetFontHeight("RobotoHUD-20") + 4)
-	but:SetText("")
-
-	function but:Paint(w, h)
-		surface.SetDrawColor(color_black)
-
-		if IsValid(ply) && ply:IsPlayer() then
-			local col = team.GetColor(ply:Team())
-			if self.Hovered then
-				surface.SetDrawColor(col.r, col.g, col.b, 20)
-				surface.DrawRect(0, 0, w, h)
-			end
-
-			local s = 4
-			if ply:IsSpeaking() then
-				surface.SetMaterial(unmuted)
-
-				local v = ply:VoiceVolume()
-				local x, y = self:LocalToScreen(0, 0)
-				render.SetScissorRect(x, y, x + s + 32 * (0.5 + v / 2), y + h, true)
-
-				-- draw mute icon
-				surface.SetDrawColor(255, 255, 255, 255)
-				surface.DrawTexturedRect(s, h / 2 - 16, 32, 32)
-				s = s + 32 + 4
-
-				render.SetScissorRect(0, 0, 0, 0, false)
-			end
-
-			if ply:IsMuted() then
-				surface.SetMaterial(muted)
-
-				-- draw mute icon
-				surface.SetDrawColor(150, 150, 150, 255)
-				surface.DrawTexturedRect(s, h / 2 - 16, 32, 32)
-				s = s + 32 + 4
-			end
-
-			draw.SimpleText(ply:Ping(), "RobotoHUD-20", w - 4, 0, col, 2)
-			draw.SimpleText(ply:Nick(), "RobotoHUD-20", s, 0, col, 0)
-		end
-	end
-
-	function but:DoClick()
-		if IsValid(ply) then
-			GAMEMODE:DoScoreboardActionPopup(ply)
-		end
-	end
-
-	mlist:AddItem(but)
-end
-
-local function doPlayerItems(self, mlist)
-	local add = false
-	for k, ply in pairs(player.GetAll()) do
-		local found = false
-		for t, v in pairs(mlist:GetCanvas():GetChildren()) do
-			if v.player == ply then
-				found = true
-				v.ctime = CurTime()
-			end
-		end
-
-		if !found then
-			addPlayerItem(self, mlist, ply)
-			add = true
-		end
-	end
-
-	local del = false
-	for t, v in pairs(mlist:GetCanvas():GetChildren()) do
-		if !v.perm && v.ctime != CurTime() then
-			v:Remove()
-			del = true
-		end
-	end
-
-	-- make sure the rest of the elements are sorted and moved up to fill gaps
-	if del || add then
-		timer.Simple(0, function()
-			local childs = mlist:GetCanvas():GetChildren()
-			table.sort(childs, function(a, b)
-				if !IsValid(a) then print(a, b, 1) return false end
-				if !IsValid(b) then print(a, b, 2) return false end
-				if !IsValid(a.player) then print(a, b, 3) return false end
-				if !IsValid(b.player) then print(a, b, 4) return false end
-				return a.player:Team() * 1000 + a.player:EntIndex() < b.player:Team() * 1000 + b.player:EntIndex()
-			end)
-
-			for k, v in pairs(childs) do
-				v:SetParent(mlist)
-			end
-
-			mlist:GetCanvas():InvalidateLayout()
-		end)
-	end
-end
-
-concommand.Add("ph_endroundmenu_close", function()
-	if IsValid(menu) then
-		menu:Close()
-	end
-end)
-
-function GM:OpenEndRoundMenu()
-	if IsValid(menu) then
-		menu:SetVisible(true)
-		return
-	end
-
+local function createEndRoundMenu()
 	menu = vgui.Create("DFrame")
-	menu:ParentToHUD()
-	GAMEMODE.EndRoundPanel = menu
-	menu:SetSize(ScrW() * 0.95, ScrH() * 0.95)
+	menu:SetSize(ScrW() * 0.4, ScrH() * 0.6)
 	menu:Center()
-	menu:SetTitle("")
+	menu:SetTitle("Results")
 	menu:MakePopup()
+	menu:SetMouseInputEnabled(true)
 	menu:SetKeyboardInputEnabled(false)
 	menu:SetDeleteOnClose(false)
-	menu:SetDraggable(false)
-	menu:ShowCloseButton(false)
-	menu:DockPadding(8, 8, 8, 8)
 
 	local matBlurScreen = Material("pp/blurscreen")
 	function menu:Paint(w, h)
-		DisableClipping(true)
-
+		-- Create a blured background to the entire menu. This makes the content easier
+		-- to read against the semi-transparent background.
 		local x, y = self:LocalToScreen(0, 0)
 		local Fraction = 0.4
 
@@ -150,170 +27,138 @@ function GM:OpenEndRoundMenu()
 			surface.DrawTexturedRect(x * -1, y * -1, ScrW(), ScrH())
 		end
 
-		surface.SetDrawColor(40, 40, 40, 230)
-		surface.DrawRect(-x, -y, ScrW(), ScrH())
-
+		-- 2 pixel thick black border on the OUTSIDE of the panel
+		-- Temporarily disable clipping so we can draw outside the bounds of menu
+		surface.SetDrawColor(0, 0, 0, 230)
+		DisableClipping(true)
+		surface.DrawOutlinedRect(-1, -1, w + 2, h + 2)
+		surface.DrawOutlinedRect(-2, -2, w + 4, h + 4)
 		DisableClipping(false)
+
+		-- Title bar rectangle (the title bar is always 22 pixels in height)
+		surface.SetDrawColor(40, 40, 40, 230)
+		surface.DrawRect(0, 0, w, 22)
+
+		-- Light grey background on lower area
+		surface.SetDrawColor(60, 60, 60, 230)
+		surface.DrawRect(0, 22, w, h)
 	end
 
-	local leftpnl = vgui.Create("DPanel", menu)
-	leftpnl:Dock(LEFT)
+	-- results section (purely a container)
+	local resultsPanel = vgui.Create("DPanel", menu)
+	menu.ResultsPanel = resultsPanel
+	resultsPanel:Dock(FILL)
 
-	function leftpnl:PerformLayout()
-		self:SetWide(menu:GetWide() * 0.4)
-	end
+	function resultsPanel:Paint(w, h) end
 
-	function leftpnl:Paint(w, h)
-	end
+	-- Text label at the top specifying who won
+	local winner = vgui.Create("DLabel", resultsPanel)
+	menu.WinningTeam = winner
+	winner:Dock(TOP)
+	winner:SetTall(draw.GetFontHeight("RobotoHUD-30"))
+	winner:SetFont("RobotoHUD-30")
+	winner:SetContentAlignment(5) -- Center
 
-	-- player list section
-	local listpnl = vgui.Create("DPanel", leftpnl)
-	listpnl:Dock(FILL)
+	-- Middle area where the player awards are listed
+	local awards = vgui.Create("DScrollPanel", resultsPanel)
+	awards:Dock(FILL)
+	menu.AwardsList = awards
+	-- awards:DockMargin(20, 20, 20, 0)
 
-	function listpnl:Paint(w, h)
+	function awards:Paint(w, h)
 		surface.SetDrawColor(20, 20, 20, 150)
-		local t = draw.GetFontHeight("RobotoHUD-25") + 2
-		surface.DrawRect(0, t, w, h - t)
+		surface.DrawRect(0, 0, w, h)
 	end
 
-	local header = vgui.Create("DLabel", listpnl)
-	header:Dock(TOP)
-	header:SetFont("RobotoHUD-25")
-	header:SetTall(draw.GetFontHeight("RobotoHUD-25"))
-	header:SetText("Player List")
-	header:DockMargin(4, 2, 4, 2)
-
-	local plist = vgui.Create("DScrollPanel", listpnl)
-	menu.PlayerList = plist
-	plist:Dock(FILL)
-
-	function plist:Paint(w, h)
-	end
-
-	function plist:Think()
-		if !self.RefreshWait || self.RefreshWait < CurTime() then
-			self.RefreshWait = CurTime() + 0.1
-			doPlayerItems(self, plist)
-		end
-	end
-
-	-- child positioning
-	local canvas = plist:GetCanvas()
+	local canvas = awards:GetCanvas()
 	canvas:DockPadding(0, 0, 0, 0)
 
 	function canvas:OnChildAdded(child)
 		child:Dock(TOP)
-		child:DockMargin(0, 0, 0, 1)
+		child:DockMargin(10, 10, 10, 0)
 	end
 
-	-- results section
-	local respnl = vgui.Create("DPanel", menu)
-	menu.ResultsPanel = respnl
-	respnl:Dock(FILL)
-	respnl:DockMargin(20, 0, 0, 0)
-	respnl:DockPadding(0, 0, 0, 0)
-
-	function respnl:Paint(w, h)
-		surface.SetDrawColor(20, 20, 20, 150)
-		local t = draw.GetFontHeight("RobotoHUD-25") + 2
-		surface.DrawRect(0, t, w, h - t)
-	end
-
-	local header = vgui.Create("DLabel", respnl)
-	header:Dock(TOP)
-	header:SetFont("RobotoHUD-25")
-	header:SetTall(draw.GetFontHeight("RobotoHUD-25"))
-	header:SetText("Results")
-	header:DockMargin(4, 2, 4, 2)
-
-	local winner = vgui.Create("DLabel", respnl)
-	menu.WinningTeam = winner
-	winner:Dock(TOP)
-	winner:DockMargin(20, 20, 20, 20)
-	winner:SetTall(draw.GetFontHeight("RobotoHUD-45"))
-	winner:SetText("Props win!")
-	winner:SetColor(team.GetColor(TEAM_PROP))
-	winner:SetFont("RobotoHUD-45")
-
-	local timeleft = vgui.Create("DPanel", respnl)
+	-- Timer at bottom right showing how long until next round/mapvote
+	local timeleft = vgui.Create("DPanel", resultsPanel)
 	timeleft:Dock(BOTTOM)
-	timeleft:SetTall(draw.GetFontHeight("RobotoHUD-20"))
-	local col = Color(150, 150, 150)
+	timeleft:SetTall(draw.GetFontHeight("RobotoHUD-15"))
 
 	function timeleft:Paint(w, h)
+		-- Extend the darker rectangle in awards:Paint to make it looks like one large seamless rectangle
+		surface.SetDrawColor(20, 20, 20, 150)
+		surface.DrawRect(0, 0, w, h)
+
 		if GAMEMODE:GetGameState() == ROUND_POST then
 			local settings = GAMEMODE:GetRoundSettings()
 			local roundTime = settings.NextRoundTime || 30
 			local time = math.max(0, roundTime - GAMEMODE:GetStateRunningTime())
-			draw.SimpleText("Next round in " .. math.ceil(time), "RobotoHUD-20", w - 4, 0, col, 2)
+			draw.DrawText("Next round in " .. math.ceil(time), "RobotoHUD-15", w - 4, 0, Color(150, 150, 150), 2)
 		end
 	end
 
-	local mlist = vgui.Create("DScrollPanel", respnl)
-	menu.ResultList = mlist
-	mlist:Dock(FILL)
-	mlist:DockMargin(20, 0, 20, 0)
 
-	function mlist:Paint(w, h)
-	end
 
-	local canvas = mlist:GetCanvas()
-	canvas:DockPadding(0, 0, 0, 0)
 
-	function canvas:OnChildAdded(child)
-		child:Dock(TOP)
-		child:DockMargin(0, 0, 0, 16)
-	end
 
-	-- map vote
-	local votepnl = vgui.Create("DPanel", menu)
-	votepnl:SetVisible(false)
-	menu.VotePanel = votepnl
-	votepnl:Dock(FILL)
-	votepnl:DockMargin(20, 0, 0, 0)
-	votepnl:DockPadding(0, 0, 0, 0)
 
-	function votepnl:Paint(w, h)
-		surface.SetDrawColor(20, 20, 20, 150)
-		local t = draw.GetFontHeight("RobotoHUD-25") + 2
-		surface.DrawRect(0, t, w, h - t)
-	end
+	if false then
+		-- map vote
+		local votepnl = vgui.Create("DPanel", menu)
+		votepnl:SetVisible(false)
+		menu.VotePanel = votepnl
+		votepnl:Dock(FILL)
+		votepnl:DockMargin(20, 0, 0, 0)
+		votepnl:DockPadding(0, 0, 0, 0)
 
-	local header = vgui.Create("DLabel", votepnl)
-	header:Dock(TOP)
-	header:SetFont("RobotoHUD-25")
-	header:SetTall(draw.GetFontHeight("RobotoHUD-25"))
-	header:SetText("Map voting")
-	header:DockMargin(4, 2, 4, 2)
+		function votepnl:Paint(w, h)
+			surface.SetDrawColor(20, 20, 20, 150)
+			local t = draw.GetFontHeight("RobotoHUD-25") + 2
+			surface.DrawRect(0, t, w, h - t)
+		end
 
-	local timeleft = vgui.Create("DPanel", votepnl)
-	timeleft:Dock(BOTTOM)
-	timeleft:SetTall(draw.GetFontHeight("RobotoHUD-20"))
-	local col = Color(150, 150, 150)
+		local header = vgui.Create("DLabel", votepnl)
+		header:Dock(TOP)
+		header:SetFont("RobotoHUD-25")
+		header:SetTall(draw.GetFontHeight("RobotoHUD-25"))
+		header:SetText("Map voting")
+		header:DockMargin(4, 2, 4, 2)
 
-	function timeleft:Paint(w, h)
-		if GAMEMODE:GetGameState() == ROUND_MAPVOTE then
-			local voteTime = GAMEMODE.MapVoteTime || 30
-			local time = math.max(0, voteTime - GAMEMODE:GetMapVoteRunningTime())
-			draw.SimpleText("Voting ends in " .. math.ceil(time), "RobotoHUD-20", w - 4, 0, col, 2)
+		local timeleft = vgui.Create("DPanel", votepnl)
+		timeleft:Dock(BOTTOM)
+		timeleft:SetTall(draw.GetFontHeight("RobotoHUD-20"))
+		local col = Color(150, 150, 150)
+
+		function timeleft:Paint(w, h)
+			if GAMEMODE:GetGameState() == ROUND_MAPVOTE then
+				local voteTime = GAMEMODE.MapVoteTime || 30
+				local time = math.max(0, voteTime - GAMEMODE:GetMapVoteRunningTime())
+				draw.SimpleText("Voting ends in " .. math.ceil(time), "RobotoHUD-20", w - 4, 0, col, 2)
+			end
+		end
+
+		local mlist = vgui.Create("DScrollPanel", votepnl)
+		menu.MapVoteList = mlist
+		mlist:Dock(FILL)
+		mlist:DockMargin(0, 20, 0, 20)
+
+		function mlist:Paint(w, h) end
+
+		local canvas = mlist:GetCanvas()
+		canvas:DockPadding(20, 0, 20, 0)
+
+		function canvas:OnChildAdded(child)
+			child:Dock(TOP)
+			child:DockMargin(0, 0, 0, 16)
 		end
 	end
+end
 
-	local mlist = vgui.Create("DScrollPanel", votepnl)
-	menu.MapVoteList = mlist
-	mlist:Dock(FILL)
-	mlist:DockMargin(0, 20, 0, 20)
-
-	function mlist:Paint(w, h)
+function GM:OpenEndRoundMenu()
+	if !IsValid(menu) then
+		createEndRoundMenu()
 	end
 
-	local canvas = mlist:GetCanvas()
-	canvas:DockPadding(20, 0, 20, 0)
-
-	function canvas:OnChildAdded(child)
-		child:Dock(TOP)
-		child:DockMargin(0, 0, 0, 16)
-	end
+	menu:SetVisible(true)
 end
 
 function GM:CloseEndRoundMenu()
@@ -326,9 +171,9 @@ function GM:EndRoundMenuResults(res)
 	self:OpenEndRoundMenu()
 
 	menu.ResultsPanel:SetVisible(true)
-	menu.VotePanel:SetVisible(false)
+	-- menu.VotePanel:SetVisible(false)
 	menu.Results = res
-	menu.ResultList:Clear()
+	menu.AwardsList:Clear()
 	if res.winningTeam == WIN_HUNTER || res.winningTeam == WIN_PROP then
 		menu.WinningTeam:SetText(team.GetName(res.winningTeam) .. " win!")
 		menu.WinningTeam:SetColor(team.GetColor(res.winningTeam))
@@ -338,17 +183,17 @@ function GM:EndRoundMenuResults(res)
 	end
 
 	for _, award in pairs(res.playerAwards) do
-		local pnl = vgui.Create("DPanel")
-		pnl:SetTall(math.max(draw.GetFontHeight("RobotoHUD-35"), draw.GetFontHeight("RobotoHUD-15") + draw.GetFontHeight("RobotoHUD-20") * 1.1))
+		local containerPanel = vgui.Create("DPanel")
+		containerPanel:SetTall(draw.GetFontHeight("RobotoHUD-20"))
 
-		function pnl:Paint(w, h)
+		function containerPanel:Paint(w, h)
 			surface.SetDrawColor(50, 50, 50)
-			draw.DrawText(award.name, "RobotoHUD-20", 0, 0, Color(220, 220, 220), 0)
-			draw.DrawText(award.desc, "RobotoHUD-15", 0, draw.GetFontHeight("RobotoHUD-20"), Color(120, 120, 120), 0)
-			draw.DrawText(award.winnerName, "RobotoHUD-25", w, h / 2 - draw.GetFontHeight("RobotoHUD-25") / 2, team.GetColor(award.winnerTeam), 2)
+			draw.DrawText(award.name, "RobotoHUD-10", 0, 0, Color(220, 220, 220), 0)
+			draw.DrawText(award.desc, "RobotoHUD-10", 0, draw.GetFontHeight("RobotoHUD-10"), Color(120, 120, 120), 0)
+			draw.DrawText(award.winnerName, "RobotoHUD-15", w, (h / 2) - (draw.GetFontHeight("RobotoHUD-20") / 2), team.GetColor(award.winnerTeam), 2)
 		end
 
-		menu.ResultList:AddItem(pnl)
+		menu.AwardsList:AddItem(containerPanel)
 	end
 end
 

--- a/gamemodes/husklesph/gamemode/cl_helpscreen.lua
+++ b/gamemodes/husklesph/gamemode/cl_helpscreen.lua
@@ -42,7 +42,7 @@ local function openHelpScreen()
 		menu:SetVisible(!menu:IsVisible())
 	else
 		menu = vgui.Create("DFrame")
-		GAMEMODE.ScoreboardPanel = menu
+		GAMEMODE.HelpMenu = menu
 		menu:SetSize(ScrW() * 0.8, ScrH() * 0.8)
 		menu:Center()
 		menu:MakePopup()

--- a/gamemodes/husklesph/gamemode/cl_hud.lua
+++ b/gamemodes/husklesph/gamemode/cl_hud.lua
@@ -210,11 +210,6 @@ function GM:HUDShouldDraw(name)
 	if name == "CHudHealth" then return false end
 	if name == "CHudVoiceStatus" then return false end
 	if name == "CHudVoiceSelfStatus" then return false end
-	if name == "CHudChat" then
-		if IsValid(self.EndRoundPanel) && self.EndRoundPanel:IsVisible() then
-			return false
-		end
-	end
 
 	return true
 end

--- a/gamemodes/husklesph/gamemode/cl_init.lua
+++ b/gamemodes/husklesph/gamemode/cl_init.lua
@@ -137,12 +137,3 @@ net.Receive("player_model_sex", function()
 	end
 	GAMEMODE.PlayerModelSex = sex
 end)
-
-function GM:StartChat()
-	if IsValid(self.EndRoundPanel) && self.EndRoundPanel:IsVisible() then
-		timer.Simple(0, function() chat.Close() end)
-		self.EndRoundPanel:SetKeyboardInputEnabled(true)
-		self.EndRoundPanel.ChatTextEntry:RequestFocus()
-		return true
-	end
-end

--- a/gamemodes/husklesph/gamemode/cl_init.lua
+++ b/gamemodes/husklesph/gamemode/cl_init.lua
@@ -127,9 +127,7 @@ function GM:EntityRemoved(ent)
 end
 
 concommand.Add("+menu_context", function()
-	if GAMEMODE:GetGameState() == ROUND_POST then
-		-- TODO: Opening the menu like this before EndRoundMenuResults has called from the
-		-- timer in cl_rounds will show the previous rounds results (until the timer fires).
+	if (GAMEMODE:GetGameState() == ROUND_POST && !timer.Exists("ph_timer_show_results_delay")) || GAMEMODE:GetGameState() == ROUND_MAPVOTE then
 		GAMEMODE:ToggleEndRoundMenuVisibility()
 	else
 		RunConsoleCommand("ph_lockrotation")

--- a/gamemodes/husklesph/gamemode/cl_init.lua
+++ b/gamemodes/husklesph/gamemode/cl_init.lua
@@ -127,7 +127,13 @@ function GM:EntityRemoved(ent)
 end
 
 concommand.Add("+menu_context", function()
-	RunConsoleCommand("ph_lockrotation")
+	if GAMEMODE:GetGameState() == ROUND_POST then
+		-- TODO: Opening the menu like this before EndRoundMenuResults has called from the
+		-- timer in cl_rounds will show the previous rounds results (until the timer fires).
+		GAMEMODE:ToggleEndRoundMenuVisibility()
+	else
+		RunConsoleCommand("ph_lockrotation")
+	end
 end)
 
 net.Receive("player_model_sex", function()

--- a/gamemodes/husklesph/gamemode/cl_rounds.lua
+++ b/gamemodes/husklesph/gamemode/cl_rounds.lua
@@ -33,7 +33,7 @@ net.Receive("round_victor", function(len)
 	tab.playerAwards = net.ReadTable()
 
 	-- open the results panel
-	timer.Simple(2, function()
+	timer.Create("ph_timer_show_results_delay", 2, 1, function()
 		GAMEMODE:EndRoundMenuResults(tab)
 	end)
 end)

--- a/gamemodes/husklesph/gamemode/cl_scoreboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_scoreboard.lua
@@ -193,7 +193,7 @@ function GM:ScoreboardRoundResults(results)
 	menu.ResultsPanel:InvalidateLayout()
 end
 
-function GM:ScoreboardShow()
+local function createScoreboardPanel()
 	menu = vgui.Create("DFrame")
 	GAMEMODE.ScoreboardPanel = menu
 	menu:SetSize(ScrW() * 0.8, ScrH() * 0.8)
@@ -295,12 +295,15 @@ function GM:ScoreboardShow()
 	menu.PropsList:Dock(FILL)
 end
 
-function GM:ScoreboardHide()
-	if GAMEMODE.GameState == ROUND_POST then
-		menu:Close()
-		return
+function GM:ScoreboardShow()
+	if !IsValid(menu) then
+		createScoreboardPanel()
 	end
 
+	menu:SetVisible(true)
+end
+
+function GM:ScoreboardHide()
 	if IsValid(menu) then
 		menu:Close()
 	end

--- a/gamemodes/husklesph/gamemode/cl_scoreboard.lua
+++ b/gamemodes/husklesph/gamemode/cl_scoreboard.lua
@@ -194,113 +194,105 @@ function GM:ScoreboardRoundResults(results)
 end
 
 function GM:ScoreboardShow()
-	if IsValid(menu) then
-		if GAMEMODE.GameState == ROUND_POST then
-			menu:SetVisible(false)
-		else
-			menu:SetVisible(true)
+	menu = vgui.Create("DFrame")
+	GAMEMODE.ScoreboardPanel = menu
+	menu:SetSize(ScrW() * 0.8, ScrH() * 0.8)
+	menu:Center()
+	menu:MakePopup()
+	menu:SetKeyboardInputEnabled(false)
+	menu:SetDeleteOnClose(false)
+	menu:SetDraggable(false)
+	menu:ShowCloseButton(false)
+	menu:SetTitle("")
+	menu:DockPadding(8, 8, 8, 8)
+
+	function menu:PerformLayout()
+		if IsValid(menu.HuntersList) then
+			menu.HuntersList:SetWidth((self:GetWide() - 16) * 0.5)
 		end
-	else
-		menu = vgui.Create("DFrame")
-		GAMEMODE.ScoreboardPanel = menu
-		menu:SetSize(ScrW() * 0.8, ScrH() * 0.8)
-		menu:Center()
-		menu:MakePopup()
-		menu:SetKeyboardInputEnabled(false)
-		menu:SetDeleteOnClose(false)
-		menu:SetDraggable(false)
-		menu:ShowCloseButton(false)
-		menu:SetTitle("")
-		menu:DockPadding(8, 8, 8, 8)
-
-		function menu:PerformLayout()
-			if IsValid(menu.HuntersList) then
-				menu.HuntersList:SetWidth((self:GetWide() - 16) * 0.5)
-			end
-		end
-
-		function menu:Paint(w, h)
-			surface.SetDrawColor(40, 40, 40, 230)
-			surface.DrawRect(0, 0, w, h)
-		end
-
-		menu.Credits = vgui.Create("DPanel", menu)
-		menu.Credits:Dock(TOP)
-		menu.Credits:DockMargin(0, 0, 0, 4)
-
-		function menu.Credits:Paint(w, h)
-			surface.SetFont("RobotoHUD-25")
-			local t = GAMEMODE.Name || ""
-			local tw = surface.GetTextSize(t)
-			draw.ShadowText(t, "RobotoHUD-25", 4, 0, Color(199, 49, 29), 0)
-			draw.ShadowText(tostring(GAMEMODE.Version || "error") .. ", maintained by Zikaeroh, code by many cool people :)", "RobotoHUD-L12", 4 + tw + 24, h  * 0.9, Color(220, 220, 220), 0, 4)
-		end
-
-		function menu.Credits:PerformLayout()
-			surface.SetFont("RobotoHUD-25")
-			local _, h = surface.GetTextSize(GAMEMODE.Name || "")
-			self:SetTall(h)
-		end
-
-		local bottom = vgui.Create("DPanel", menu)
-		bottom:SetTall(draw.GetFontHeight("RobotoHUD-15") * 1.3)
-		bottom:Dock(BOTTOM)
-		bottom:DockMargin(0, 8, 0, 0)
-
-		surface.SetFont("RobotoHUD-15")
-		local tw = surface.GetTextSize("Spectate")
-
-		function bottom:Paint(w, h)
-			local c
-			for k, ply in pairs(team.GetPlayers(TEAM_SPEC)) do
-				if c then
-					c = c .. ", " .. ply:Nick()
-				else
-					c = ply:Nick()
-				end
-			end
-
-			if c then
-				draw.ShadowText(c, "RobotoHUD-10", tw + 8 + 4, h / 2, color_white, 0, 1)
-			end
-		end
-
-		local but = vgui.Create("DButton", bottom)
-		but:Dock(LEFT)
-		but:SetText("")
-		but:DockMargin(0, 0, 4, 0)
-		but:SetWide(tw + 8)
-
-		function but:Paint(w, h)
-			local col = Color(90, 90, 90, 160)
-			local colt = Color(190, 190, 190)
-			if self:IsDown() then
-				colMul(colt, 0.5)
-			elseif self:IsHovered() then
-				colMul(colt, 1.2)
-			end
-
-			draw.RoundedBox(4, 0, 0, w, h, col)
-			draw.ShadowText("Spectate", "RobotoHUD-15", w / 2, h / 2, colt, 1, 1)
-		end
-
-		function but:DoClick()
-			RunConsoleCommand("ph_jointeam", TEAM_SPEC)
-		end
-
-		local main = vgui.Create("DPanel", menu)
-		main:Dock(FILL)
-
-		function main:Paint(w, h)
-			surface.SetDrawColor(40, 40, 40, 230)
-		end
-
-		menu.HuntersList = makeTeamList(main, TEAM_HUNTER)
-		menu.HuntersList:Dock(LEFT)
-		menu.HuntersList:DockMargin(0, 0, 8, 0)
-		menu.PropsList = makeTeamList(main, TEAM_PROP)
-		menu.PropsList:Dock(FILL)
 	end
+
+	function menu:Paint(w, h)
+		surface.SetDrawColor(40, 40, 40, 230)
+		surface.DrawRect(0, 0, w, h)
+	end
+
+	menu.Credits = vgui.Create("DPanel", menu)
+	menu.Credits:Dock(TOP)
+	menu.Credits:DockMargin(0, 0, 0, 4)
+
+	function menu.Credits:Paint(w, h)
+		surface.SetFont("RobotoHUD-25")
+		local t = GAMEMODE.Name || ""
+		local tw = surface.GetTextSize(t)
+		draw.ShadowText(t, "RobotoHUD-25", 4, 0, Color(199, 49, 29), 0)
+		draw.ShadowText(tostring(GAMEMODE.Version || "error") .. ", maintained by Zikaeroh, code by many cool people :)", "RobotoHUD-L12", 4 + tw + 24, h  * 0.9, Color(220, 220, 220), 0, 4)
+	end
+
+	function menu.Credits:PerformLayout()
+		surface.SetFont("RobotoHUD-25")
+		local _, h = surface.GetTextSize(GAMEMODE.Name || "")
+		self:SetTall(h)
+	end
+
+	local bottom = vgui.Create("DPanel", menu)
+	bottom:SetTall(draw.GetFontHeight("RobotoHUD-15") * 1.3)
+	bottom:Dock(BOTTOM)
+	bottom:DockMargin(0, 8, 0, 0)
+
+	surface.SetFont("RobotoHUD-15")
+	local tw = surface.GetTextSize("Spectate")
+
+	function bottom:Paint(w, h)
+		local c
+		for k, ply in pairs(team.GetPlayers(TEAM_SPEC)) do
+			if c then
+				c = c .. ", " .. ply:Nick()
+			else
+				c = ply:Nick()
+			end
+		end
+
+		if c then
+			draw.ShadowText(c, "RobotoHUD-10", tw + 8 + 4, h / 2, color_white, 0, 1)
+		end
+	end
+
+	local but = vgui.Create("DButton", bottom)
+	but:Dock(LEFT)
+	but:SetText("")
+	but:DockMargin(0, 0, 4, 0)
+	but:SetWide(tw + 8)
+
+	function but:Paint(w, h)
+		local col = Color(90, 90, 90, 160)
+		local colt = Color(190, 190, 190)
+		if self:IsDown() then
+			colMul(colt, 0.5)
+		elseif self:IsHovered() then
+			colMul(colt, 1.2)
+		end
+
+		draw.RoundedBox(4, 0, 0, w, h, col)
+		draw.ShadowText("Spectate", "RobotoHUD-15", w / 2, h / 2, colt, 1, 1)
+	end
+
+	function but:DoClick()
+		RunConsoleCommand("ph_jointeam", TEAM_SPEC)
+	end
+
+	local main = vgui.Create("DPanel", menu)
+	main:Dock(FILL)
+
+	function main:Paint(w, h)
+		surface.SetDrawColor(40, 40, 40, 230)
+	end
+
+	menu.HuntersList = makeTeamList(main, TEAM_HUNTER)
+	menu.HuntersList:Dock(LEFT)
+	menu.HuntersList:DockMargin(0, 0, 8, 0)
+	menu.PropsList = makeTeamList(main, TEAM_PROP)
+	menu.PropsList:Dock(FILL)
 end
 
 function GM:ScoreboardHide()


### PR DESCRIPTION
Removed the player list and chat menu from the endround results menu. Only the player awards section remains.
The endround menu no longer takes up the entire screen. It has been turned into a window that you can drag around and close.
The `+menu_context` keybind (same key used for locking prop rotation) can be used to open and close the endround menu during the post round and mapvote stages of the game.
The font size of almost every item in both the results menu and mapvote menu has been decreased by 5-10. This is to allow it to better fit in the smaller menu.

I changed the way in which a number of the menu elements are created/sized/positioned in an effort to have the menu look consistent across resolutions. The two main resolutions I tested with are 2560x1440 and 1920x1080. The menu looks good at both of those resolutions (and I assume any intermediary ones). I can make no guarantees about how things will look above 2560x1440,  ~~but I can say that things will start to really break at resolutions below 1920x1080 (1280x720 is barely useable).~~ This is actually incorrect as my initial test of 1280x720 was flawed, it actually works perfectly fine.

New 2560x1440 (Results, Mapvote)
![](https://user-images.githubusercontent.com/6549826/80096117-efaf2480-851d-11ea-980a-e477b11dbd77.png)
![](https://user-images.githubusercontent.com/6549826/80097997-030fbf00-8521-11ea-8e0c-e61afb8f24ba.png)

New 1920x1080 (Results)
![](https://user-images.githubusercontent.com/6549826/80096178-fdfd4080-851d-11ea-9254-0f0a7d0761ba.png)

New 1280x720 (Mapvote, showing the scroll bar does work if it's required)
![](https://user-images.githubusercontent.com/6549826/80098104-2e92a980-8521-11ea-91b1-04585c7826e3.png)

Old 1920x1080 (Results)
![](https://user-images.githubusercontent.com/6549826/80096158-f9d12300-851d-11ea-8caa-378834270916.png)
